### PR TITLE
Rename uart0 to uart_0

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ logger:
   baud_rate: 0
 
 uart:
-  id: uart0
+  id: uart_0
   baud_rate: 2400
   tx_pin: GPIO1
   rx_pin: GPIO3

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -36,7 +36,7 @@ mqtt:
 # api:
 
 uart:
-  - id: uart0
+  - id: uart_0
     baud_rate: 9600
     tx_pin: ${tx_pin}
     rx_pin: ${rx_pin}
@@ -46,6 +46,7 @@ uart:
 
 modbus:
   - id: modbus0
+    uart_id: uart_0
     send_wait_time: 200ms
 
 modbus_controller:

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -34,7 +34,7 @@ mqtt:
 # api:
 
 uart:
-  - id: uart0
+  - id: uart_0
     baud_rate: 9600
     tx_pin: ${tx_pin}
     rx_pin: ${rx_pin}
@@ -44,6 +44,7 @@ uart:
 
 modbus:
   - id: modbus0
+    uart_id: uart_0
     send_wait_time: 200ms
 
 modbus_controller:


### PR DESCRIPTION
This change is required by ESPHome 2023.4.0

See https://github.com/esphome/esphome/pull/4446