### PR TITLE
Add number entity for the `battery low voltage protection point in off-grid mode`

### DIFF
--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -1014,6 +1014,22 @@ number:
     write_lambda: |-
       return x * 10.0f;
 
+  # Battery low voltage protection point in off-grid mode          0.1V           Uint  329 1 R/W
+  - platform: modbus_controller
+    modbus_controller_id: smg0
+    name: "${name} battery low voltage protection point in off-grid mode"
+    use_write_multiple: true
+    address: 329
+    register_type: holding
+    value_type: U_WORD
+    min_value: 0.0
+    # max_value: 100.0
+    step: 0.1
+    unit_of_measurement: "V"
+    lambda: "return x * 0.1f;"
+    write_lambda: |-
+      return x * 10.0f;
+
   # Maximum charging current                                      0.1A    Uint  332 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -1012,6 +1012,22 @@ number:
     write_lambda: |-
       return x * 10.0f;
 
+  # Battery low voltage protection point in off-grid mode          0.1V           Uint  329 1 R/W
+  - platform: modbus_controller
+    modbus_controller_id: smg0
+    name: "${name} battery low voltage protection point in off-grid mode"
+    use_write_multiple: true
+    address: 329
+    register_type: holding
+    value_type: U_WORD
+    min_value: 0.0
+    # max_value: 100.0
+    step: 0.1
+    unit_of_measurement: "V"
+    lambda: "return x * 0.1f;"
+    write_lambda: |-
+      return x * 10.0f;
+
   # Maximum charging current                                      0.1A    Uint  332 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0


### PR DESCRIPTION
Great work with the example file, I just found out that there was an address missing in the examples. 

Feel free to squash the commits (I edited it in the web UI).