### PR TITLE
Remove redundant name substitution prefix from entity names

### DIFF
--- a/esp32-example-advanced-multiple-uarts.yaml
+++ b/esp32-example-advanced-multiple-uarts.yaml
@@ -10,6 +10,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   min_version: 2024.6.0
   project:

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -60,7 +60,7 @@ time:
 
 sensor:
   - platform: total_daily_energy
-    name: "${name} PV energy today"
+    name: "PV energy today"
     restore: true
     device_class: energy
     power_id: smg0_pv_average_power
@@ -70,7 +70,7 @@ sensor:
     unit_of_measurement: kWh
 
   - platform: template
-    name: "${name} discharging power"
+    name: "discharging power"
     id: smg0_discharging_power
     unit_of_measurement: "W"
     device_class: power
@@ -86,7 +86,7 @@ sensor:
       return (power < 0.0f) ? -power : 0.0f;
 
   - platform: template
-    name: "${name} charging power"
+    name: "charging power"
     id: smg0_charging_power
     unit_of_measurement: "W"
     device_class: power
@@ -104,7 +104,7 @@ sensor:
   # Fault code                                                    ULong 100 2 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} fault code"
+    name: "fault code"
     address: 100
     register_type: holding
     value_type: U_DWORD
@@ -114,7 +114,7 @@ sensor:
   # Warning code                                                  ULong 108 2 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} warning code"
+    name: "warning code"
     address: 108
     register_type: holding
     value_type: U_DWORD
@@ -130,7 +130,7 @@ sensor:
   #                                                                             6: Fault
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} operation mode id"
+    name: "operation mode id"
     address: 201
     register_type: holding
     value_type: U_WORD
@@ -140,7 +140,7 @@ sensor:
   # Effective mains voltage                              0.1V     Int   202 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} ac voltage"
+    name: "ac voltage"
     address: 202
     register_type: holding
     value_type: S_WORD
@@ -154,7 +154,7 @@ sensor:
   # Mains Frequency                                      0.01Hz   Int   203 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} ac frequency"
+    name: "ac frequency"
     address: 203
     register_type: holding
     value_type: S_WORD
@@ -168,7 +168,7 @@ sensor:
   # Average mains power                                  1W       Int   204 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} average mains power"
+    name: "average mains power"
     address: 204
     register_type: holding
     value_type: S_WORD
@@ -180,7 +180,7 @@ sensor:
   # Effective inverter voltage                           0.1V     Int   205 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} effective inverter voltage"
+    name: "effective inverter voltage"
     address: 205
     register_type: holding
     value_type: S_WORD
@@ -194,7 +194,7 @@ sensor:
   # Effective inverter current                           0.1A     Int   206 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} effective inverter current"
+    name: "effective inverter current"
     address: 206
     register_type: holding
     value_type: S_WORD
@@ -208,7 +208,7 @@ sensor:
   # Inverter frequency                                   0.01Hz   Int   207 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} inverter frequency"
+    name: "inverter frequency"
     address: 207
     register_type: holding
     value_type: S_WORD
@@ -222,7 +222,7 @@ sensor:
   # Average inverter power                               1W       Int   208 1 R Positive numbers indicate inverter output, negative numbers indicate inverter input
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} average inverter power"
+    name: "average inverter power"
     address: 208
     register_type: holding
     value_type: S_WORD
@@ -234,7 +234,7 @@ sensor:
   # Inverter charging power                              1W       Int   209 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} inverter charging power"
+    name: "inverter charging power"
     address: 209
     register_type: holding
     value_type: S_WORD
@@ -246,7 +246,7 @@ sensor:
   # Output effective voltage                             0.1V     Int   210 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output effective voltage"
+    name: "output effective voltage"
     address: 210
     register_type: holding
     value_type: S_WORD
@@ -260,7 +260,7 @@ sensor:
   # Output effective Current                             0.1A     Int   211 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output effective Current"
+    name: "output effective Current"
     address: 211
     register_type: holding
     value_type: S_WORD
@@ -274,7 +274,7 @@ sensor:
   # Output frequency                                     0.01Hz   Int   212 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output frequency"
+    name: "output frequency"
     address: 212
     register_type: holding
     value_type: S_WORD
@@ -288,7 +288,7 @@ sensor:
   # Output active power                                  1W       Int   213 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output active power"
+    name: "output active power"
     address: 213
     register_type: holding
     value_type: S_WORD
@@ -300,7 +300,7 @@ sensor:
   # Output apparent power                                1VA      Int   214 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output apparent power"
+    name: "output apparent power"
     address: 214
     register_type: holding
     value_type: S_WORD
@@ -312,7 +312,7 @@ sensor:
   # Battery average voltage                              0.1V     Int   215 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery average voltage"
+    name: "battery average voltage"
     address: 215
     register_type: holding
     value_type: S_WORD
@@ -326,7 +326,7 @@ sensor:
   # Battery average Current                              0.1A     Int   216 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery average current"
+    name: "battery average current"
     address: 216
     register_type: holding
     value_type: S_WORD
@@ -340,7 +340,7 @@ sensor:
   # Battery average power                                1W       Int   217 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery average power"
+    name: "battery average power"
     id: smg0_battery_average_power
     address: 217
     register_type: holding
@@ -356,7 +356,7 @@ sensor:
   # PV average voltage                                   0.1V     Int   219 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} pv average voltage"
+    name: "pv average voltage"
     address: 219
     register_type: holding
     value_type: S_WORD
@@ -370,7 +370,7 @@ sensor:
   # PV average current                                   0.1A     Int   220 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} pv average current"
+    name: "pv average current"
     address: 220
     register_type: holding
     value_type: S_WORD
@@ -385,7 +385,7 @@ sensor:
   - platform: modbus_controller
     modbus_controller_id: smg0
     id: smg0_pv_average_power
-    name: "${name} pv average power"
+    name: "pv average power"
     address: 223
     register_type: holding
     value_type: S_WORD
@@ -397,7 +397,7 @@ sensor:
   # PV charging average power                            1W       Int   224 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} pv charging average power"
+    name: "pv charging average power"
     address: 224
     register_type: holding
     value_type: S_WORD
@@ -409,7 +409,7 @@ sensor:
   # Load percentage                                      1%       Int   225 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} load percentage"
+    name: "load percentage"
     address: 225
     register_type: holding
     value_type: S_WORD
@@ -421,7 +421,7 @@ sensor:
   # DCDC Temperature                                     1°C      Int   226 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} dcdc temperature"
+    name: "dcdc temperature"
     address: 226
     register_type: holding
     value_type: S_WORD
@@ -433,7 +433,7 @@ sensor:
   # Inverter Temperature                                 1°C      Int   227 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} inverter temperature"
+    name: "inverter temperature"
     address: 227
     register_type: holding
     value_type: S_WORD
@@ -445,7 +445,7 @@ sensor:
   # Battery state of charge                              1%       UInt  229 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery state of charge"
+    name: "battery state of charge"
     address: 229
     register_type: holding
     value_type: U_WORD
@@ -457,7 +457,7 @@ sensor:
   # Battery average current                              0.1A     Int   232 1 R Positive number means charging, negative number means discharging
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery average current2"
+    name: "battery average current2"
     address: 232
     register_type: holding
     value_type: S_WORD
@@ -471,7 +471,7 @@ sensor:
   # Inverter charging average current                    0.1A     Int   233 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} inverter charging average current"
+    name: "inverter charging average current"
     address: 233
     register_type: holding
     value_type: S_WORD
@@ -485,7 +485,7 @@ sensor:
   # PV charging average current                          0.1A     Int   234 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} pv charging average current"
+    name: "pv charging average current"
     address: 234
     register_type: holding
     value_type: S_WORD
@@ -499,7 +499,7 @@ sensor:
   # # Output voltage                                        0.1V    Uint  320 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} output voltage"
+  #   name: "output voltage"
   #   address: 320
   #   register_type: holding
   #   value_type: U_WORD
@@ -513,7 +513,7 @@ sensor:
   # # Output frequency setting                              0.01Hz  Uint  321 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} output frequency setting"
+  #   name: "output frequency setting"
   #   address: 321
   #   register_type: holding
   #   value_type: U_WORD
@@ -527,7 +527,7 @@ sensor:
   # # Battery overvoltage protection point                  0.1V    Uint  323 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} battery overvoltage protection point"
+  #   name: "battery overvoltage protection point"
   #   address: 323
   #   register_type: holding
   #   value_type: U_WORD
@@ -541,7 +541,7 @@ sensor:
   # # Max charging voltage                                  0.1V    Uint  324 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} max charging voltage"
+  #   name: "max charging voltage"
   #   address: 324
   #   register_type: holding
   #   value_type: U_WORD
@@ -555,7 +555,7 @@ sensor:
   # # Floating charging voltage                             0.1V    Uint  325 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} floating charging voltage"
+  #   name: "floating charging voltage"
   #   address: 325
   #   register_type: holding
   #   value_type: U_WORD
@@ -569,7 +569,7 @@ sensor:
   # # Battery discharge recovery point in mains mode        0.1V    Uint  326 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} battery discharge recovery point in mains mode"
+  #   name: "battery discharge recovery point in mains mode"
   #   address: 326
   #   register_type: holding
   #   value_type: U_WORD
@@ -583,7 +583,7 @@ sensor:
   # # Battery low voltage protection point in mains mode    0.1V    Uint  327 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} battery low voltage protection point in mains mode"
+  #   name: "battery low voltage protection point in mains mode"
   #   address: 327
   #   register_type: holding
   #   value_type: U_WORD
@@ -597,7 +597,7 @@ sensor:
   # # Battery low voltage protection point in off-grid mode 0.1V    Uint  329 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} battery low voltage protection point in off-grid mode"
+  #   name: "battery low voltage protection point in off-grid mode"
   #   address: 329
   #   register_type: holding
   #   value_type: U_WORD
@@ -611,7 +611,7 @@ sensor:
   # # Maximum charging current                              0.1A    Uint  332 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} maximum charging current"
+  #   name: "maximum charging current"
   #   address: 332
   #   register_type: holding
   #   value_type: U_WORD
@@ -625,7 +625,7 @@ sensor:
   # # Maximum mains charging current                        0.1A    Uint  333 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} maximum mains charging current"
+  #   name: "maximum mains charging current"
   #   address: 333
   #   register_type: holding
   #   value_type: U_WORD
@@ -639,7 +639,7 @@ sensor:
   # # Eq Charging voltage                                   0.1V    Uint  334 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} Eq Charging voltage"
+  #   name: "Eq Charging voltage"
   #   address: 334
   #   register_type: holding
   #   value_type: U_WORD
@@ -653,7 +653,7 @@ sensor:
   # Rated power                                           W       Uint  643 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} rated power"
+    name: "rated power"
     address: 643
     register_type: holding
     value_type: U_WORD
@@ -666,7 +666,7 @@ select:
   # Output Mode                                                   Uint  300 1 R/W 0: Single, 1: Parallel, 2: 3 Phase-P1, 3: 3 Phase-P2, 4: 3 Phase-P3
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output mode"
+    name: "output mode"
     use_write_multiple: true
     address: 300
     value_type: U_WORD
@@ -682,7 +682,7 @@ select:
   # Output priority                                               Uint  301 1 R/W 0: Utility-PV-Battery, 1: PV-Utility-Battery, 2: PV-Battery-Utility
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output priority"
+    name: "output priority"
     use_write_multiple: true
     address: 301
     value_type: U_WORD
@@ -697,7 +697,7 @@ select:
   # Input voltage range                                           Uint  302 1 R/W 0: Wide range, 1: Narrow range
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} input voltage range"
+    name: "input voltage range"
     use_write_multiple: true
     address: 302
     value_type: U_WORD
@@ -710,7 +710,7 @@ select:
   # Buzzer mode                                                   Uint  303 1 R/W 0: Mute in all situations, 1: Sound when the input source is changed or there is a specific warning or fault, 2: Sound when there is aspecific warning or fault, 3: Sound when fault occurs
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} buzzer mode"
+    name: "buzzer mode"
     use_write_multiple: true
     address: 303
     value_type: U_WORD
@@ -725,7 +725,7 @@ select:
   # LCD backlight                                                 Uint  305 1 R/W 0: Timed off, 1: Always on
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} lcd backlight"
+    name: "lcd backlight"
     use_write_multiple: true
     address: 305
     value_type: U_WORD
@@ -738,7 +738,7 @@ select:
   # Battery charging priority                                     Uint  331 1 R/W 0: Utility priority, 1: PV priority, 2: PV is at the same level as the Utility, 3: Only PV charging is allowed
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery charging priority"
+    name: "battery charging priority"
     use_write_multiple: true
     address: 331
     value_type: U_WORD
@@ -753,7 +753,7 @@ select:
   # Turn on mode                                                  Uint  406 1 R/W 0: Can be turn-on locally or remotely, 1: Only local turn-on, 2: Only remote turn-on
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} turn on mode"
+    name: "turn on mode"
     use_write_multiple: true
     address: 406
     value_type: U_WORD
@@ -766,7 +766,7 @@ select:
 
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery type"
+    name: "battery type"
     use_write_multiple: true
     address: 322
     value_type: U_WORD
@@ -786,7 +786,7 @@ switch:
   # LCD automatically returns to the homepage                     Uint  306 1 R/W 0: Do not return automatically, 1: Automatically return after 1 minute
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} lcd automatically returns to the homepage"
+    name: "lcd automatically returns to the homepage"
     use_write_multiple: true
     address: 306
     register_type: holding
@@ -796,7 +796,7 @@ switch:
   # Energy-saving mode                                            Uint  307 1 R/W 0: Energy-saving mode is off, 1: Energy-saving mode is on
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} energy-saving mode"
+    name: "energy-saving mode"
     use_write_multiple: true
     address: 307
     register_type: holding
@@ -806,7 +806,7 @@ switch:
   # Overload automatic restart                                    Uint  308 1 R/W 0: Overload failure will not restart, 1: Automatic restart after overload failure
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} overload automatic restart"
+    name: "overload automatic restart"
     use_write_multiple: true
     address: 308
     register_type: holding
@@ -816,7 +816,7 @@ switch:
   # Over temperature automatic restart                            Uint  309 1 R/W 0: Over temperature failure will not restart, 1: Automatic restart after over-temperature fault
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} over temperature automatic restart"
+    name: "over temperature automatic restart"
     use_write_multiple: true
     address: 309
     register_type: holding
@@ -826,7 +826,7 @@ switch:
   # Overload transfer to bypass enabled                           Uint  310 1 R/W 0: Disable, 1: Enable
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} overload transfer to bypass enabled"
+    name: "overload transfer to bypass enabled"
     use_write_multiple: true
     address: 310
     register_type: holding
@@ -836,7 +836,7 @@ switch:
   # Battery Eq mode is enabled                                    Uint  313 1 R/W 0: Disable, 1: Enable
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery Eq mode is enabled"
+    name: "battery Eq mode is enabled"
     use_write_multiple: true
     address: 313
     register_type: holding
@@ -846,7 +846,7 @@ switch:
   # Remote switch                                                 Uint  420 1 R/W 0: Remote shutdown, 1: Remote turn-on
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} remote switch"
+    name: "remote switch"
     use_write_multiple: true
     address: 420
     register_type: holding
@@ -857,7 +857,7 @@ text_sensor:
   # Fault code                                                    ULong 100 2 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} fault"
+    name: "fault"
     address: 100
     register_type: holding
     register_count: 2
@@ -914,7 +914,7 @@ text_sensor:
   # Warning code                                                  ULong 108 2 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} warning"
+    name: "warning"
     address: 108
     register_type: holding
     register_count: 2
@@ -963,7 +963,7 @@ text_sensor:
   # Operation Mode                                                UInt  201 1 R 0: Power On, 1: Standby, 2: Mains, 3: Off-Grid, 4: Bypass, 5: Charging, 6: Fault
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} operation mode"
+    name: "operation mode"
     address: 201
     register_type: holding
     raw_encode: HEXBYTES
@@ -985,7 +985,7 @@ number:
   # Output voltage                                                0.1V    Uint  320 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output voltage"
+    name: "output voltage"
     use_write_multiple: true
     address: 320
     register_type: holding
@@ -1003,7 +1003,7 @@ number:
   # Output frequency setting                                      0.01Hz  Uint  321 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output frequency setting"
+    name: "output frequency setting"
     use_write_multiple: true
     address: 321
     register_type: holding
@@ -1021,7 +1021,7 @@ number:
   # Battery overvoltage protection point                          0.1V    Uint  323 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery overvoltage protection point"
+    name: "battery overvoltage protection point"
     use_write_multiple: true
     address: 323
     register_type: holding
@@ -1039,7 +1039,7 @@ number:
   # Max charging voltage                                          0.1V    Uint  324 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} max charging voltage"
+    name: "max charging voltage"
     use_write_multiple: true
     address: 324
     register_type: holding
@@ -1057,7 +1057,7 @@ number:
   # Floating charging voltage                                     0.1V    Uint  325 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} floating charging voltage"
+    name: "floating charging voltage"
     use_write_multiple: true
     address: 325
     register_type: holding
@@ -1075,7 +1075,7 @@ number:
   # Battery discharge recovery point in mains mode                0.1V    Uint  326 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery discharge recovery point in mains mode"
+    name: "battery discharge recovery point in mains mode"
     use_write_multiple: true
     address: 326
     register_type: holding
@@ -1093,7 +1093,7 @@ number:
   # Battery low voltage protection point in mains mode            0.1V    Uint  327 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery low voltage protection point in mains mode"
+    name: "battery low voltage protection point in mains mode"
     use_write_multiple: true
     address: 327
     register_type: holding
@@ -1111,7 +1111,7 @@ number:
   # Battery low voltage protection point in off-grid mode          0.1V           Uint  329 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery low voltage protection point in off-grid mode"
+    name: "battery low voltage protection point in off-grid mode"
     use_write_multiple: true
     address: 329
     register_type: holding
@@ -1129,7 +1129,7 @@ number:
   # Maximum charging current                                      0.1A    Uint  332 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} maximum charging current"
+    name: "maximum charging current"
     use_write_multiple: true
     address: 332
     register_type: holding
@@ -1147,7 +1147,7 @@ number:
   # Maximum mains charging current                                0.1A    Uint  333 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} maximum mains charging current"
+    name: "maximum mains charging current"
     use_write_multiple: true
     address: 333
     register_type: holding
@@ -1165,7 +1165,7 @@ number:
   # Eq Charging voltage                                           0.1V    Uint  334 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} Eq Charging voltage"
+    name: "Eq Charging voltage"
     use_write_multiple: true
     address: 334
     register_type: holding
@@ -1183,7 +1183,7 @@ number:
   # Battery equalization time                                     min     Uint  335 1 R/W Range: 0~900
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery equalization time"
+    name: "battery equalization time"
     use_write_multiple: true
     address: 335
     register_type: holding
@@ -1198,7 +1198,7 @@ number:
   # Equalization Timeout exit                                     min     Uint  336 1 R/W Range: 0~900
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} equalization Timeout exit"
+    name: "equalization Timeout exit"
     use_write_multiple: true
     address: 336
     register_type: holding
@@ -1213,7 +1213,7 @@ number:
   # Two equalization charging intervals                           day     Uint  337 1 R/W Range: 1~90
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} two equalization charging intervals"
+    name: "two equalization charging intervals"
     use_write_multiple: true
     address: 337
     register_type: holding
@@ -1228,7 +1228,7 @@ number:
   # SOC point back to utility source                           %       Uint  341 1 R/W Value Menu 43 minimum setting value must be more than the value of program 45
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} SOC point back to utility"
+    name: "SOC point back to utility"
     use_write_multiple: true
     address: 341
     register_type: holding
@@ -1243,7 +1243,7 @@ number:
   # SOC point back to battery                        %       Uint  342 1 R/W Value Menu 44 60%~100% Settable
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} SOC point back to battery"
+    name: "SOC point back to battery"
     use_write_multiple: true
     address: 342
     register_type: holding
@@ -1258,7 +1258,7 @@ number:
   # Low DC cut-off SOC                 %       Uint  343 1 R/W Value Menu 45 3%~30% the max setting value must be less than the value of program 43.
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} Low DC cut-off SOC"
+    name: "Low DC cut-off SOC"
     use_write_multiple: true
     address: 343
     register_type: holding
@@ -1273,7 +1273,7 @@ number:
 button:
   # Exit the fault mode                                           Uint  426   W   1: Exit the fault state
   - platform: template
-    name: "${name} exit fault state"
+    name: "exit fault state"
     icon: mdi:restore
     on_press:
       then:

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   min_version: 2024.6.0
   project:

--- a/esp32-gm6200-example.yaml
+++ b/esp32-gm6200-example.yaml
@@ -57,7 +57,7 @@ time:
 
 sensor:
   - platform: total_daily_energy
-    name: "${name} Battery discharge today"
+    name: "Battery discharge today"
     restore: true
     device_class: energy
     power_id: smg0_discharging_power
@@ -67,7 +67,7 @@ sensor:
     unit_of_measurement: kWh
 
   - platform: total_daily_energy
-    name: "${name} Battery charge today"
+    name: "Battery charge today"
     restore: true
     device_class: energy
     power_id: smg0_charging_power
@@ -77,7 +77,7 @@ sensor:
     unit_of_measurement: kWh
 
   - platform: template
-    name: "${name} discharging power"
+    name: "discharging power"
     id: smg0_discharging_power
     unit_of_measurement: "W"
     device_class: power
@@ -93,7 +93,7 @@ sensor:
       return (power < 0.0f) ? -power : 0.0f;
 
   - platform: template
-    name: "${name} charging power"
+    name: "charging power"
     id: smg0_charging_power
     unit_of_measurement: "W"
     device_class: power
@@ -111,7 +111,7 @@ sensor:
   ## Fault code                                                    ULong 100 2 R
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} fault code"
+  #   name: "fault code"
   #   address: 100
   #   register_type: holding
   #   value_type: U_DWORD
@@ -120,7 +120,7 @@ sensor:
   # Warning code                                                  ULong 108 2 R
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} warning code"
+  #   name: "warning code"
   #   address: 108
   #   register_type: holding
   #   value_type: U_DWORD
@@ -130,7 +130,7 @@ sensor:
   # Device Type	 	UInt	171	1	R
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} Device Type"
+  #   name: "Device Type"
   #   address: 171
   #   register_type: holding
   #   value_type: U_WORD
@@ -139,7 +139,7 @@ sensor:
   # Protocol Number	 	UInt	184	1	R	The protocol number of this protocol is 0x02
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} Protocol Number"
+  #   name: "Protocol Number"
   #   address: 171
   #   register_type: holding
   #   value_type: U_WORD
@@ -154,7 +154,7 @@ sensor:
   #                                                                             6: Fault
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} operation mode id"
+  #   name: "operation mode id"
   #   address: 201
   #   register_type: holding
   #   value_type: U_WORD
@@ -163,7 +163,7 @@ sensor:
   # Effective mains voltage                              0.1V     Int   202 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} ac voltage"
+    name: "ac voltage"
     address: 202
     register_type: holding
     value_type: S_WORD
@@ -177,7 +177,7 @@ sensor:
   # Mains Frequency                                      0.01Hz   Int   203 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} ac frequency"
+    name: "ac frequency"
     address: 203
     register_type: holding
     value_type: S_WORD
@@ -191,7 +191,7 @@ sensor:
   # Average mains power                                  1W       Int   204 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} average mains power"
+    name: "average mains power"
     address: 204
     register_type: holding
     value_type: S_WORD
@@ -203,7 +203,7 @@ sensor:
   # Effective inverter voltage                           0.1V     Int   205 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} effective inverter voltage"
+    name: "effective inverter voltage"
     address: 205
     register_type: holding
     value_type: S_WORD
@@ -217,7 +217,7 @@ sensor:
   # Effective inverter current                           0.1A     Int   206 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} effective inverter current"
+    name: "effective inverter current"
     address: 206
     register_type: holding
     value_type: S_WORD
@@ -231,7 +231,7 @@ sensor:
   # Inverter frequency                                   0.01Hz   Int   207 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} inverter frequency"
+    name: "inverter frequency"
     address: 207
     register_type: holding
     value_type: S_WORD
@@ -245,7 +245,7 @@ sensor:
   # Average inverter power                               1W       Int   208 1 R Positive numbers indicate inverter output, negative numbers indicate inverter input
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} average inverter power"
+    name: "average inverter power"
     address: 208
     register_type: holding
     value_type: S_WORD
@@ -257,7 +257,7 @@ sensor:
   # Inverter charging power                              1W       Int   209 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} inverter charging power"
+    name: "inverter charging power"
     address: 209
     register_type: holding
     value_type: S_WORD
@@ -270,7 +270,7 @@ sensor:
   # Output effective voltage                             0.1V     Int   210 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output effective voltage"
+    name: "output effective voltage"
     address: 210
     register_type: holding
     value_type: S_WORD
@@ -284,7 +284,7 @@ sensor:
   # Output effective Current                             0.1A     Int   211 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output effective Current"
+    name: "output effective Current"
     address: 211
     register_type: holding
     value_type: S_WORD
@@ -298,7 +298,7 @@ sensor:
   # Output frequency                                     0.01Hz   Int   212 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output frequency"
+    name: "output frequency"
     address: 212
     register_type: holding
     value_type: S_WORD
@@ -312,7 +312,7 @@ sensor:
   # Output active power                                  1W       Int   213 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output active power"
+    name: "output active power"
     address: 213
     register_type: holding
     value_type: S_WORD
@@ -324,7 +324,7 @@ sensor:
   # Output apparent power                                1VA      Int   214 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output apparent power"
+    name: "output apparent power"
     address: 214
     register_type: holding
     value_type: S_WORD
@@ -336,7 +336,7 @@ sensor:
   # Battery average voltage                              0.1V     Int   215 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery average voltage"
+    name: "battery average voltage"
     address: 215
     register_type: holding
     value_type: S_WORD
@@ -350,7 +350,7 @@ sensor:
   # Battery average Current                              0.1A     Int   216 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery average current"
+    name: "battery average current"
     address: 216
     register_type: holding
     value_type: S_WORD
@@ -365,7 +365,7 @@ sensor:
   # Battery average power                                1W       Int   217 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery average power"
+    name: "battery average power"
     id: smg0_battery_average_power
     address: 217
     register_type: holding
@@ -381,7 +381,7 @@ sensor:
   # PV average voltage                                   0.1V     Int   219 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} pv average voltage"
+    name: "pv average voltage"
     address: 219
     register_type: holding
     value_type: S_WORD
@@ -396,7 +396,7 @@ sensor:
   # PV average current                                   0.1A     Int   220 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} pv average current"
+    name: "pv average current"
     address: 220
     register_type: holding
     value_type: S_WORD
@@ -412,7 +412,7 @@ sensor:
   - platform: modbus_controller
     modbus_controller_id: smg0
     id: smg0_pv_average_power
-    name: "${name} pv average power"
+    name: "pv average power"
     address: 223
     register_type: holding
     value_type: S_WORD
@@ -425,7 +425,7 @@ sensor:
   # PV charging average power                            1W       Int   224 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} pv charging average power"
+    name: "pv charging average power"
     address: 224
     register_type: holding
     value_type: S_WORD
@@ -438,7 +438,7 @@ sensor:
   # Load percentage                                      1%       Int   225 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} load percentage"
+    name: "load percentage"
     address: 225
     register_type: holding
     value_type: S_WORD
@@ -450,7 +450,7 @@ sensor:
   # DCDC Temperature                                     1°C      Int   226 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} dcdc temperature"
+    name: "dcdc temperature"
     address: 226
     register_type: holding
     value_type: S_WORD
@@ -462,7 +462,7 @@ sensor:
   # Inverter Temperature                                 1°C      Int   227 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} inverter temperature"
+    name: "inverter temperature"
     address: 227
     register_type: holding
     value_type: S_WORD
@@ -474,7 +474,7 @@ sensor:
   # PV temperature                                       1°C      Int   228 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} PV temperature"
+    name: "PV temperature"
     address: 228
     register_type: holding
     value_type: S_WORD
@@ -486,7 +486,7 @@ sensor:
   # Battery state of charge                              1%       UInt  229 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery state of charge"
+    name: "battery state of charge"
     address: 229
     register_type: holding
     value_type: U_WORD
@@ -508,7 +508,7 @@ sensor:
   # bit13  0: Load icon is on                            1: Load icon is off
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} power flow status"
+    name: "power flow status"
     address: 231
     register_type: holding
     value_type: U_WORD
@@ -518,7 +518,7 @@ sensor:
   # Battery average current                              0.1A     Int   232 1 R Positive number means charging, negative number means discharging
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery average current2"
+    name: "battery average current2"
     address: 232
     register_type: holding
     value_type: S_WORD
@@ -533,7 +533,7 @@ sensor:
   # Inverter charging average current                    0.1A     Int   233 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} inverter charging average current"
+    name: "inverter charging average current"
     address: 233
     register_type: holding
     value_type: S_WORD
@@ -548,7 +548,7 @@ sensor:
   # PV charging average current                          0.1A     Int   234 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} pv charging average current"
+    name: "pv charging average current"
     address: 234
     register_type: holding
     value_type: S_WORD
@@ -563,7 +563,7 @@ sensor:
   # External CT sampling power                             1W       Int   235 2 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} external CT power"
+    name: "external CT power"
     address: 235
     register_type: holding
     value_type: S_DWORD
@@ -575,7 +575,7 @@ sensor:
   # Power generation on the day                            0.01Kwh  Uint   443 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} PV energy today"
+    name: "PV energy today"
     address: 443
     register_type: holding
     value_type: U_WORD
@@ -590,7 +590,7 @@ sensor:
   ## Rated power                                           W       Uint  643 1 R
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} rated power"
+  #   name: "rated power"
   #   address: 643
   #   register_type: holding
   #   value_type: U_WORD
@@ -602,7 +602,7 @@ sensor:
   ## Rated number of battery cells [J]                                          PCS       Uint  644 1 R
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} rated number of battery cells "
+  #   name: "rated number of battery cells "
   #   address: 644
   #   register_type: holding
   #   value_type: U_WORD
@@ -614,7 +614,7 @@ select:
   # Output Mode                                                   Uint  300 1 R/W 0: Single, 1: Parallel, 2: 3 Phase-P1, 3: 3 Phase-P2, 4: 3 Phase-P3
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output mode"
+    name: "output mode"
     use_write_multiple: true
     address: 300
     value_type: U_WORD
@@ -630,7 +630,7 @@ select:
   # Output priority                                               Uint  301 1 R/W 0: Utility-PV-Battery, 1: PV-Utility-Battery, 2: PV-Battery-Utility
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output priority"
+    name: "output priority"
     use_write_multiple: true
     address: 301
     value_type: U_WORD
@@ -646,7 +646,7 @@ select:
   # Input voltage range                                           Uint  302 1 R/W 0: Wide range, 1: Narrow range
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} input voltage range"
+    name: "input voltage range"
     use_write_multiple: true
     address: 302
     value_type: U_WORD
@@ -660,7 +660,7 @@ select:
   # Buzzer mode                                                   Uint  303 1 R/W 0: Mute in all situations, 1: Sound when the input source is changed or there is a specific warning or fault, 2: Sound when there is aspecific warning or fault, 3: Sound when fault occurs
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} buzzer mode"
+    name: "buzzer mode"
     use_write_multiple: true
     address: 303
     value_type: U_WORD
@@ -675,7 +675,7 @@ select:
   # LCD backlight                                                 Uint  305 1 R/W 0: Timed off, 1: Always on
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} lcd backlight"
+    name: "lcd backlight"
     use_write_multiple: true
     address: 305
     value_type: U_WORD
@@ -688,7 +688,7 @@ select:
   # Auxiliary Output priority                                     Uint  318 1 R/W 0: Close the secondary output priority 1: PV-mains-battery (SUB) [priority inverter] 2: PV-battery-mains (SBU) 3: PV-mains-battery (SUF) [PV can be connected to the grid] 4: PV-battery-mains (ZEC) [self-generation and self-use]
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} aux output priority"
+    name: "aux output priority"
     use_write_multiple: true
     address: 318
     value_type: U_WORD
@@ -704,7 +704,7 @@ select:
   # Auxiliary battery charging priority                                     Uint  319 1 R/W 0: Utility priority, 1: PV priority, 2: PV is at the same level as the Utility, 3: Only PV charging is allowed
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} aux battery charging priority"
+    name: "aux battery charging priority"
     use_write_multiple: true
     address: 319
     value_type: U_WORD
@@ -720,7 +720,7 @@ select:
   # Battery Type                                                 Uint  322 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery type"
+    name: "battery type"
     address: 322
     value_type: U_WORD
     icon: mdi:cog
@@ -738,7 +738,7 @@ select:
   # Battery charging priority                                     Uint  331 1 R/W 0: Utility priority, 1: PV priority, 2: PV is at the same level as the Utility, 3: Only PV charging is allowed
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery charging priority"
+    name: "battery charging priority"
     use_write_multiple: true
     address: 331
     value_type: U_WORD
@@ -753,7 +753,7 @@ select:
   # Turn on mode                                                  Uint  406 1 R/W 0: Can be turn-on locally or remotely, 1: Only local turn-on, 2: Only remote turn-on
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} turn on mode"
+    name: "turn on mode"
     use_write_multiple: true
     address: 406
     value_type: U_WORD
@@ -768,7 +768,7 @@ switch:
   # LCD automatically returns to the homepage                     Uint  306 1 R/W 0: Do not return automatically, 1: Automatically return after 1 minute
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} lcd automatically returns to the homepage"
+    name: "lcd automatically returns to the homepage"
     use_write_multiple: true
     address: 306
     register_type: holding
@@ -778,7 +778,7 @@ switch:
   # Energy-saving mode                                            Uint  307 1 R/W 0: Energy-saving mode is off, 1: Energy-saving mode is on
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} energy-saving mode"
+    name: "energy-saving mode"
     use_write_multiple: true
     address: 307
     register_type: holding
@@ -788,7 +788,7 @@ switch:
   # Overload automatic restart                                    Uint  308 1 R/W 0: Overload failure will not restart, 1: Automatic restart after overload failure
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} overload automatic restart"
+    name: "overload automatic restart"
     use_write_multiple: true
     address: 308
     register_type: holding
@@ -798,7 +798,7 @@ switch:
   # Over temperature automatic restart                            Uint  309 1 R/W 0: Over temperature failure will not restart, 1: Automatic restart after over-temperature fault
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} over temperature automatic restart"
+    name: "over temperature automatic restart"
     use_write_multiple: true
     address: 309
     register_type: holding
@@ -808,7 +808,7 @@ switch:
   # Overload transfer to bypass enabled                           Uint  310 1 R/W 0: Disable, 1: Enable
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} overload transfer to bypass enabled"
+    name: "overload transfer to bypass enabled"
     use_write_multiple: true
     address: 310
     register_type: holding
@@ -818,7 +818,7 @@ switch:
   # Parallel PV detection mode                                   Uint  311 1 R/W 0: Disable, 1: Enable
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} parallel PV detection mode"
+    name: "parallel PV detection mode"
     use_write_multiple: true
     address: 311
     register_type: holding
@@ -828,7 +828,7 @@ switch:
   # External CT Enable                                           Uint  312 1 R/W 0: Disable, 1: Enable
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} external CT Enable"
+    name: "external CT Enable"
     use_write_multiple: true
     address: 312
     register_type: holding
@@ -838,7 +838,7 @@ switch:
   # Battery Eq mode is enabled                                    Uint  313 1 R/W 0: Disable, 1: Enable
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery Eq mode is enabled"
+    name: "battery Eq mode is enabled"
     use_write_multiple: true
     address: 313
     register_type: holding
@@ -848,7 +848,7 @@ switch:
   # Automatic mains output enable                                Uint   338 1 R/W 0: No AC power output if the power button is not pressed  1: Automatic AC power output if the power button is not pressed
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} Automatic mains output enable"
+    name: "Automatic mains output enable"
     use_write_multiple: true
     address: 338
     register_type: holding
@@ -858,7 +858,7 @@ switch:
   # Island detection enable                                       Uint  352 1 R/W 0: Disable island detection 1: Enable island detection
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} island detection"
+    name: "island detection"
     use_write_multiple: true
     address: 352
     register_type: holding
@@ -868,7 +868,7 @@ switch:
   # Remote switch                                                 Uint  420 1 R/W 0: Remote shutdown, 1: Remote turn-on
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} remote switch"
+    name: "remote switch"
     use_write_multiple: true
     address: 420
     register_type: holding
@@ -879,7 +879,7 @@ text_sensor:
   # Fault code                                                    ULong 100 2 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} fault"
+    name: "fault"
     address: 100
     register_type: holding
     register_count: 2
@@ -938,7 +938,7 @@ text_sensor:
   # Warning code                                                  ULong 108 2 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} warning"
+    name: "warning"
     address: 108
     register_type: holding
     register_count: 2
@@ -990,7 +990,7 @@ text_sensor:
   ## Device Name                                                  ASC   172 12 R/W Device name, written or read in ASCII format
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} Device Name"
+  #   name: "Device Name"
   #   address: 172
   #   register_type: holding
   #   raw_encode: ANSI
@@ -1000,7 +1000,7 @@ text_sensor:
   ## Device serial number                                         ASC   186 12 R
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} Device serial number"
+  #   name: "Device serial number"
   #   address: 186
   #   register_type: holding
   #   raw_encode: ANSI
@@ -1010,7 +1010,7 @@ text_sensor:
   # Operation Mode                                                UInt  201 1 R 0: Power On, 1: Standby, 2: Mains, 3: Off-Grid, 4: Bypass, 5: Charging, 6: Fault
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} operation mode"
+    name: "operation mode"
     address: 201
     register_type: holding
     raw_encode: HEXBYTES
@@ -1031,7 +1031,7 @@ text_sensor:
   ## Program Version                                                 ASC   626 8 R
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} Program Version"
+  #   name: "Program Version"
   #   address: 626
   #   register_type: holding
   #   raw_encode: ANSI
@@ -1042,7 +1042,7 @@ number:
   # Output voltage                                                0.1V    Uint  320 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output voltage"
+    name: "output voltage"
     use_write_multiple: true
     address: 320
     register_type: holding
@@ -1060,7 +1060,7 @@ number:
   # Output frequency setting                                      0.01Hz  Uint  321 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output frequency setting"
+    name: "output frequency setting"
     use_write_multiple: true
     address: 321
     register_type: holding
@@ -1079,7 +1079,7 @@ number:
   # Range: ( B + 1v * J ) ~ 16.5v * J
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery overvoltage protection point"
+    name: "battery overvoltage protection point"
     use_write_multiple: true
     address: 323
     register_type: holding
@@ -1098,7 +1098,7 @@ number:
   # Range: C ~ ( A - 1v)
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} max charging voltage"
+    name: "max charging voltage"
     use_write_multiple: true
     address: 324
     register_type: holding
@@ -1117,7 +1117,7 @@ number:
   # Range: (12v * J ) ~ B
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} floating charging voltage"
+    name: "floating charging voltage"
     use_write_multiple: true
     address: 325
     register_type: holding
@@ -1135,7 +1135,7 @@ number:
   # Battery discharge recovery point in mains mode                0.1V    Uint  326 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery discharge recovery point in mains mode"
+    name: "battery discharge recovery point in mains mode"
     use_write_multiple: true
     address: 326
     register_type: holding
@@ -1153,7 +1153,7 @@ number:
   # Battery low voltage protection point in mains mode            0.1V    Uint  327 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery low voltage protection point in mains mode"
+    name: "battery low voltage protection point in mains mode"
     use_write_multiple: true
     address: 327
     register_type: holding
@@ -1171,7 +1171,7 @@ number:
   # Battery low voltage protection point in off-grid mode          0.1V           Uint  329 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery low voltage protection point in off-grid mode"
+    name: "battery low voltage protection point in off-grid mode"
     use_write_multiple: true
     address: 329
     register_type: holding
@@ -1189,7 +1189,7 @@ number:
   # Maximum charging current                                      0.1A    Uint  332 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} maximum charging current"
+    name: "maximum charging current"
     use_write_multiple: true
     address: 332
     register_type: holding
@@ -1207,7 +1207,7 @@ number:
   # Maximum mains charging current                                0.1A    Uint  333 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} maximum mains charging current"
+    name: "maximum mains charging current"
     use_write_multiple: true
     address: 333
     register_type: holding
@@ -1225,7 +1225,7 @@ number:
   # Eq Charging voltage                                           0.1V    Uint  334 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} Eq Charging voltage"
+    name: "Eq Charging voltage"
     use_write_multiple: true
     address: 334
     register_type: holding
@@ -1243,7 +1243,7 @@ number:
   # Battery equalization time                                     min     Uint  335 1 R/W Range: 0~900
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery equalization time"
+    name: "battery equalization time"
     use_write_multiple: true
     address: 335
     register_type: holding
@@ -1258,7 +1258,7 @@ number:
   # Equalization Timeout exit                                     min     Uint  336 1 R/W Range: 0~900
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} equalization Timeout exit"
+    name: "equalization Timeout exit"
     use_write_multiple: true
     address: 336
     register_type: holding
@@ -1273,7 +1273,7 @@ number:
   # Two equalization charging intervals                           day     Uint  337 1 R/W Range: 1~90
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} two equalization charging intervals"
+    name: "two equalization charging intervals"
     use_write_multiple: true
     address: 337
     register_type: holding
@@ -1288,7 +1288,7 @@ number:
   # Battery discharge SOC protection value in AC mode [K]           1%    Uint   341 1 R/W Range: 20%~50%
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} Battery discharge SOC protection value in AC mode [K]"
+    name: "Battery discharge SOC protection value in AC mode [K]"
     use_write_multiple: true
     address: 341
     register_type: holding
@@ -1303,7 +1303,7 @@ number:
   # Battery discharge SOC recovery value in AC mode                  1%    Uint   342 1 R/W Range: 60%~100%
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} Battery discharge SOC recovery value in AC mode"
+    name: "Battery discharge SOC recovery value in AC mode"
     use_write_multiple: true
     address: 342
     register_type: holding
@@ -1318,7 +1318,7 @@ number:
   # Off-grid mode battery discharge SOC protection value              1%    Uint   343 1 R/W Range: 3%~Min( K , 30%)
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} Off-grid mode battery discharge SOC protection value"
+    name: "Off-grid mode battery discharge SOC protection value"
     use_write_multiple: true
     address: 343
     register_type: holding
@@ -1333,7 +1333,7 @@ number:
   # PV grid-connected maximum power                                    1w    Uint   344 1 R/W Range: 200w~ rated power
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} PV grid-connected maximum power"
+    name: "PV grid-connected maximum power"
     use_write_multiple: true
     address: 344
     register_type: holding
@@ -1349,7 +1349,7 @@ number:
   # UNDOCUMENTED!! CT detection error compensation                                   349 1 R/W Range: -200:200
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} CT detection error compensation"
+    name: "CT detection error compensation"
     use_write_multiple: true
     address: 349
     register_type: holding
@@ -1362,7 +1362,7 @@ number:
   # Maximum discharge current protection                                1A    Uint   351 1 R/W Maximum discharge current protection value in stand-alone mode
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} maximum discharge current protection"
+    name: "maximum discharge current protection"
     use_write_multiple: true
     address: 351
     register_type: holding

--- a/esp32-gm6200-example.yaml
+++ b/esp32-gm6200-example.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   min_version: 2024.6.0
 

--- a/esp32-usb-example.yaml
+++ b/esp32-usb-example.yaml
@@ -75,7 +75,7 @@ time:
 
 sensor:
   - platform: total_daily_energy
-    name: "${name} PV energy today"
+    name: "PV energy today"
     restore: true
     device_class: energy
     power_id: smg0_pv_average_power
@@ -85,7 +85,7 @@ sensor:
     unit_of_measurement: kWh
 
   - platform: template
-    name: "${name} discharging power"
+    name: "discharging power"
     id: smg0_discharging_power
     unit_of_measurement: "W"
     device_class: power
@@ -101,7 +101,7 @@ sensor:
       return (power < 0.0f) ? -power : 0.0f;
 
   - platform: template
-    name: "${name} charging power"
+    name: "charging power"
     id: smg0_charging_power
     unit_of_measurement: "W"
     device_class: power
@@ -119,7 +119,7 @@ sensor:
   # Fault code                                                    ULong 100 2 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} fault code"
+    name: "fault code"
     address: 100
     register_type: holding
     value_type: U_DWORD
@@ -129,7 +129,7 @@ sensor:
   # Warning code                                                  ULong 108 2 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} warning code"
+    name: "warning code"
     address: 108
     register_type: holding
     value_type: U_DWORD
@@ -145,7 +145,7 @@ sensor:
   #                                                                             6: Fault
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} operation mode id"
+    name: "operation mode id"
     address: 201
     register_type: holding
     value_type: U_WORD
@@ -155,7 +155,7 @@ sensor:
   # Effective mains voltage                              0.1V     Int   202 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} ac voltage"
+    name: "ac voltage"
     address: 202
     register_type: holding
     value_type: S_WORD
@@ -169,7 +169,7 @@ sensor:
   # Mains Frequency                                      0.01Hz   Int   203 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} ac frequency"
+    name: "ac frequency"
     address: 203
     register_type: holding
     value_type: S_WORD
@@ -183,7 +183,7 @@ sensor:
   # Average mains power                                  1W       Int   204 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} average mains power"
+    name: "average mains power"
     address: 204
     register_type: holding
     value_type: S_WORD
@@ -195,7 +195,7 @@ sensor:
   # Effective inverter voltage                           0.1V     Int   205 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} effective inverter voltage"
+    name: "effective inverter voltage"
     address: 205
     register_type: holding
     value_type: S_WORD
@@ -209,7 +209,7 @@ sensor:
   # Effective inverter current                           0.1A     Int   206 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} effective inverter current"
+    name: "effective inverter current"
     address: 206
     register_type: holding
     value_type: S_WORD
@@ -223,7 +223,7 @@ sensor:
   # Inverter frequency                                   0.01Hz   Int   207 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} inverter frequency"
+    name: "inverter frequency"
     address: 207
     register_type: holding
     value_type: S_WORD
@@ -237,7 +237,7 @@ sensor:
   # Average inverter power                               1W       Int   208 1 R Positive numbers indicate inverter output, negative numbers indicate inverter input
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} average inverter power"
+    name: "average inverter power"
     address: 208
     register_type: holding
     value_type: S_WORD
@@ -249,7 +249,7 @@ sensor:
   # Inverter charging power                              1W       Int   209 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} inverter charging power"
+    name: "inverter charging power"
     address: 209
     register_type: holding
     value_type: S_WORD
@@ -261,7 +261,7 @@ sensor:
   # Output effective voltage                             0.1V     Int   210 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output effective voltage"
+    name: "output effective voltage"
     address: 210
     register_type: holding
     value_type: S_WORD
@@ -275,7 +275,7 @@ sensor:
   # Output effective Current                             0.1A     Int   211 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output effective Current"
+    name: "output effective Current"
     address: 211
     register_type: holding
     value_type: S_WORD
@@ -289,7 +289,7 @@ sensor:
   # Output frequency                                     0.01Hz   Int   212 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output frequency"
+    name: "output frequency"
     address: 212
     register_type: holding
     value_type: S_WORD
@@ -303,7 +303,7 @@ sensor:
   # Output active power                                  1W       Int   213 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output active power"
+    name: "output active power"
     address: 213
     register_type: holding
     value_type: S_WORD
@@ -315,7 +315,7 @@ sensor:
   # Output apparent power                                1VA      Int   214 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output apparent power"
+    name: "output apparent power"
     address: 214
     register_type: holding
     value_type: S_WORD
@@ -327,7 +327,7 @@ sensor:
   # Battery average voltage                              0.1V     Int   215 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery average voltage"
+    name: "battery average voltage"
     address: 215
     register_type: holding
     value_type: S_WORD
@@ -341,7 +341,7 @@ sensor:
   # Battery average Current                              0.1A     Int   216 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery average current"
+    name: "battery average current"
     address: 216
     register_type: holding
     value_type: S_WORD
@@ -355,7 +355,7 @@ sensor:
   # Battery average power                                1W       Int   217 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery average power"
+    name: "battery average power"
     id: smg0_battery_average_power
     address: 217
     register_type: holding
@@ -371,7 +371,7 @@ sensor:
   # PV average voltage                                   0.1V     Int   219 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} pv average voltage"
+    name: "pv average voltage"
     address: 219
     register_type: holding
     value_type: S_WORD
@@ -385,7 +385,7 @@ sensor:
   # PV average current                                   0.1A     Int   220 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} pv average current"
+    name: "pv average current"
     address: 220
     register_type: holding
     value_type: S_WORD
@@ -400,7 +400,7 @@ sensor:
   - platform: modbus_controller
     modbus_controller_id: smg0
     id: smg0_pv_average_power
-    name: "${name} pv average power"
+    name: "pv average power"
     address: 223
     register_type: holding
     value_type: S_WORD
@@ -412,7 +412,7 @@ sensor:
   # PV charging average power                            1W       Int   224 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} pv charging average power"
+    name: "pv charging average power"
     address: 224
     register_type: holding
     value_type: S_WORD
@@ -424,7 +424,7 @@ sensor:
   # Load percentage                                      1%       Int   225 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} load percentage"
+    name: "load percentage"
     address: 225
     register_type: holding
     value_type: S_WORD
@@ -436,7 +436,7 @@ sensor:
   # DCDC Temperature                                     1°C      Int   226 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} dcdc temperature"
+    name: "dcdc temperature"
     address: 226
     register_type: holding
     value_type: S_WORD
@@ -448,7 +448,7 @@ sensor:
   # Inverter Temperature                                 1°C      Int   227 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} inverter temperature"
+    name: "inverter temperature"
     address: 227
     register_type: holding
     value_type: S_WORD
@@ -460,7 +460,7 @@ sensor:
   # Battery state of charge                              1%       UInt  229 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery state of charge"
+    name: "battery state of charge"
     address: 229
     register_type: holding
     value_type: U_WORD
@@ -472,7 +472,7 @@ sensor:
   # Battery average current                              0.1A     Int   232 1 R Positive number means charging, negative number means discharging
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery average current2"
+    name: "battery average current2"
     address: 232
     register_type: holding
     value_type: S_WORD
@@ -486,7 +486,7 @@ sensor:
   # Inverter charging average current                    0.1A     Int   233 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} inverter charging average current"
+    name: "inverter charging average current"
     address: 233
     register_type: holding
     value_type: S_WORD
@@ -500,7 +500,7 @@ sensor:
   # PV charging average current                          0.1A     Int   234 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} pv charging average current"
+    name: "pv charging average current"
     address: 234
     register_type: holding
     value_type: S_WORD
@@ -514,7 +514,7 @@ sensor:
   # # Output voltage                                        0.1V    Uint  320 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} output voltage"
+  #   name: "output voltage"
   #   address: 320
   #   register_type: holding
   #   value_type: U_WORD
@@ -528,7 +528,7 @@ sensor:
   # # Output frequency setting                              0.01Hz  Uint  321 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} output frequency setting"
+  #   name: "output frequency setting"
   #   address: 321
   #   register_type: holding
   #   value_type: U_WORD
@@ -542,7 +542,7 @@ sensor:
   # # Battery overvoltage protection point                  0.1V    Uint  323 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} battery overvoltage protection point"
+  #   name: "battery overvoltage protection point"
   #   address: 323
   #   register_type: holding
   #   value_type: U_WORD
@@ -556,7 +556,7 @@ sensor:
   # # Max charging voltage                                  0.1V    Uint  324 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} max charging voltage"
+  #   name: "max charging voltage"
   #   address: 324
   #   register_type: holding
   #   value_type: U_WORD
@@ -570,7 +570,7 @@ sensor:
   # # Floating charging voltage                             0.1V    Uint  325 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} floating charging voltage"
+  #   name: "floating charging voltage"
   #   address: 325
   #   register_type: holding
   #   value_type: U_WORD
@@ -584,7 +584,7 @@ sensor:
   # # Battery discharge recovery point in mains mode        0.1V    Uint  326 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} battery discharge recovery point in mains mode"
+  #   name: "battery discharge recovery point in mains mode"
   #   address: 326
   #   register_type: holding
   #   value_type: U_WORD
@@ -598,7 +598,7 @@ sensor:
   # # Battery low voltage protection point in mains mode    0.1V    Uint  327 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} battery low voltage protection point in mains mode"
+  #   name: "battery low voltage protection point in mains mode"
   #   address: 327
   #   register_type: holding
   #   value_type: U_WORD
@@ -612,7 +612,7 @@ sensor:
   # # Battery low voltage protection point in off-grid mode 0.1V    Uint  329 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} battery low voltage protection point in off-grid mode"
+  #   name: "battery low voltage protection point in off-grid mode"
   #   address: 329
   #   register_type: holding
   #   value_type: U_WORD
@@ -626,7 +626,7 @@ sensor:
   # # Maximum charging current                              0.1A    Uint  332 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} maximum charging current"
+  #   name: "maximum charging current"
   #   address: 332
   #   register_type: holding
   #   value_type: U_WORD
@@ -640,7 +640,7 @@ sensor:
   # # Maximum mains charging current                        0.1A    Uint  333 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} maximum mains charging current"
+  #   name: "maximum mains charging current"
   #   address: 333
   #   register_type: holding
   #   value_type: U_WORD
@@ -654,7 +654,7 @@ sensor:
   # # Eq Charging voltage                                   0.1V    Uint  334 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} Eq Charging voltage"
+  #   name: "Eq Charging voltage"
   #   address: 334
   #   register_type: holding
   #   value_type: U_WORD
@@ -668,7 +668,7 @@ sensor:
   # Rated power                                           W       Uint  643 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} rated power"
+    name: "rated power"
     address: 643
     register_type: holding
     value_type: U_WORD
@@ -681,7 +681,7 @@ select:
   # Output Mode                                                   Uint  300 1 R/W 0: Single, 1: Parallel, 2: 3 Phase-P1, 3: 3 Phase-P2, 4: 3 Phase-P3
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output mode"
+    name: "output mode"
     use_write_multiple: true
     address: 300
     value_type: U_WORD
@@ -697,7 +697,7 @@ select:
   # Output priority                                               Uint  301 1 R/W 0: Utility-PV-Battery, 1: PV-Utility-Battery, 2: PV-Battery-Utility
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output priority"
+    name: "output priority"
     use_write_multiple: true
     address: 301
     value_type: U_WORD
@@ -712,7 +712,7 @@ select:
   # Input voltage range                                           Uint  302 1 R/W 0: Wide range, 1: Narrow range
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} input voltage range"
+    name: "input voltage range"
     use_write_multiple: true
     address: 302
     value_type: U_WORD
@@ -725,7 +725,7 @@ select:
   # Buzzer mode                                                   Uint  303 1 R/W 0: Mute in all situations, 1: Sound when the input source is changed or there is a specific warning or fault, 2: Sound when there is aspecific warning or fault, 3: Sound when fault occurs
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} buzzer mode"
+    name: "buzzer mode"
     use_write_multiple: true
     address: 303
     value_type: U_WORD
@@ -740,7 +740,7 @@ select:
   # LCD backlight                                                 Uint  305 1 R/W 0: Timed off, 1: Always on
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} lcd backlight"
+    name: "lcd backlight"
     use_write_multiple: true
     address: 305
     value_type: U_WORD
@@ -753,7 +753,7 @@ select:
   # Battery charging priority                                     Uint  331 1 R/W 0: Utility priority, 1: PV priority, 2: PV is at the same level as the Utility, 3: Only PV charging is allowed
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery charging priority"
+    name: "battery charging priority"
     use_write_multiple: true
     address: 331
     value_type: U_WORD
@@ -768,7 +768,7 @@ select:
   # Turn on mode                                                  Uint  406 1 R/W 0: Can be turn-on locally or remotely, 1: Only local turn-on, 2: Only remote turn-on
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} turn on mode"
+    name: "turn on mode"
     use_write_multiple: true
     address: 406
     value_type: U_WORD
@@ -781,7 +781,7 @@ select:
 
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery type"
+    name: "battery type"
     use_write_multiple: true
     address: 322
     value_type: U_WORD
@@ -801,7 +801,7 @@ switch:
   # LCD automatically returns to the homepage                     Uint  306 1 R/W 0: Do not return automatically, 1: Automatically return after 1 minute
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} lcd automatically returns to the homepage"
+    name: "lcd automatically returns to the homepage"
     use_write_multiple: true
     address: 306
     register_type: holding
@@ -811,7 +811,7 @@ switch:
   # Energy-saving mode                                            Uint  307 1 R/W 0: Energy-saving mode is off, 1: Energy-saving mode is on
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} energy-saving mode"
+    name: "energy-saving mode"
     use_write_multiple: true
     address: 307
     register_type: holding
@@ -821,7 +821,7 @@ switch:
   # Overload automatic restart                                    Uint  308 1 R/W 0: Overload failure will not restart, 1: Automatic restart after overload failure
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} overload automatic restart"
+    name: "overload automatic restart"
     use_write_multiple: true
     address: 308
     register_type: holding
@@ -831,7 +831,7 @@ switch:
   # Over temperature automatic restart                            Uint  309 1 R/W 0: Over temperature failure will not restart, 1: Automatic restart after over-temperature fault
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} over temperature automatic restart"
+    name: "over temperature automatic restart"
     use_write_multiple: true
     address: 309
     register_type: holding
@@ -841,7 +841,7 @@ switch:
   # Overload transfer to bypass enabled                           Uint  310 1 R/W 0: Disable, 1: Enable
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} overload transfer to bypass enabled"
+    name: "overload transfer to bypass enabled"
     use_write_multiple: true
     address: 310
     register_type: holding
@@ -851,7 +851,7 @@ switch:
   # Battery Eq mode is enabled                                    Uint  313 1 R/W 0: Disable, 1: Enable
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery Eq mode is enabled"
+    name: "battery Eq mode is enabled"
     use_write_multiple: true
     address: 313
     register_type: holding
@@ -861,7 +861,7 @@ switch:
   # Remote switch                                                 Uint  420 1 R/W 0: Remote shutdown, 1: Remote turn-on
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} remote switch"
+    name: "remote switch"
     use_write_multiple: true
     address: 420
     register_type: holding
@@ -872,7 +872,7 @@ text_sensor:
   # Fault code                                                    ULong 100 2 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} fault"
+    name: "fault"
     address: 100
     register_type: holding
     register_count: 2
@@ -929,7 +929,7 @@ text_sensor:
   # Warning code                                                  ULong 108 2 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} warning"
+    name: "warning"
     address: 108
     register_type: holding
     register_count: 2
@@ -978,7 +978,7 @@ text_sensor:
   # Operation Mode                                                UInt  201 1 R 0: Power On, 1: Standby, 2: Mains, 3: Off-Grid, 4: Bypass, 5: Charging, 6: Fault
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} operation mode"
+    name: "operation mode"
     address: 201
     register_type: holding
     raw_encode: HEXBYTES
@@ -1000,7 +1000,7 @@ number:
   # Output voltage                                                0.1V    Uint  320 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output voltage"
+    name: "output voltage"
     use_write_multiple: true
     address: 320
     register_type: holding
@@ -1018,7 +1018,7 @@ number:
   # Output frequency setting                                      0.01Hz  Uint  321 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output frequency setting"
+    name: "output frequency setting"
     use_write_multiple: true
     address: 321
     register_type: holding
@@ -1036,7 +1036,7 @@ number:
   # Battery overvoltage protection point                          0.1V    Uint  323 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery overvoltage protection point"
+    name: "battery overvoltage protection point"
     use_write_multiple: true
     address: 323
     register_type: holding
@@ -1054,7 +1054,7 @@ number:
   # Max charging voltage                                          0.1V    Uint  324 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} max charging voltage"
+    name: "max charging voltage"
     use_write_multiple: true
     address: 324
     register_type: holding
@@ -1072,7 +1072,7 @@ number:
   # Floating charging voltage                                     0.1V    Uint  325 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} floating charging voltage"
+    name: "floating charging voltage"
     use_write_multiple: true
     address: 325
     register_type: holding
@@ -1090,7 +1090,7 @@ number:
   # Battery discharge recovery point in mains mode                0.1V    Uint  326 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery discharge recovery point in mains mode"
+    name: "battery discharge recovery point in mains mode"
     use_write_multiple: true
     address: 326
     register_type: holding
@@ -1108,7 +1108,7 @@ number:
   # Battery low voltage protection point in mains mode            0.1V    Uint  327 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery low voltage protection point in mains mode"
+    name: "battery low voltage protection point in mains mode"
     use_write_multiple: true
     address: 327
     register_type: holding
@@ -1126,7 +1126,7 @@ number:
   # Battery low voltage protection point in off-grid mode          0.1V           Uint  329 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery low voltage protection point in off-grid mode"
+    name: "battery low voltage protection point in off-grid mode"
     use_write_multiple: true
     address: 329
     register_type: holding
@@ -1144,7 +1144,7 @@ number:
   # Maximum charging current                                      0.1A    Uint  332 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} maximum charging current"
+    name: "maximum charging current"
     use_write_multiple: true
     address: 332
     register_type: holding
@@ -1162,7 +1162,7 @@ number:
   # Maximum mains charging current                                0.1A    Uint  333 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} maximum mains charging current"
+    name: "maximum mains charging current"
     use_write_multiple: true
     address: 333
     register_type: holding
@@ -1180,7 +1180,7 @@ number:
   # Eq Charging voltage                                           0.1V    Uint  334 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} Eq Charging voltage"
+    name: "Eq Charging voltage"
     use_write_multiple: true
     address: 334
     register_type: holding
@@ -1198,7 +1198,7 @@ number:
   # Battery equalization time                                     min     Uint  335 1 R/W Range: 0~900
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery equalization time"
+    name: "battery equalization time"
     use_write_multiple: true
     address: 335
     register_type: holding
@@ -1213,7 +1213,7 @@ number:
   # Equalization Timeout exit                                     min     Uint  336 1 R/W Range: 0~900
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} equalization Timeout exit"
+    name: "equalization Timeout exit"
     use_write_multiple: true
     address: 336
     register_type: holding
@@ -1228,7 +1228,7 @@ number:
   # Two equalization charging intervals                           day     Uint  337 1 R/W Range: 1~90
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} two equalization charging intervals"
+    name: "two equalization charging intervals"
     use_write_multiple: true
     address: 337
     register_type: holding
@@ -1243,7 +1243,7 @@ number:
 button:
   # Exit the fault mode                                           Uint  426   W   1: Exit the fault state
   - platform: template
-    name: "${name} exit fault state"
+    name: "exit fault state"
     icon: mdi:restore
     on_press:
       then:

--- a/esp32-usb-example.yaml
+++ b/esp32-usb-example.yaml
@@ -9,6 +9,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   min_version: 2025.7.1
   project:

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -58,7 +58,7 @@ time:
 
 sensor:
   - platform: total_daily_energy
-    name: "${name} PV energy today"
+    name: "PV energy today"
     restore: true
     device_class: energy
     power_id: smg0_pv_average_power
@@ -68,7 +68,7 @@ sensor:
     unit_of_measurement: kWh
 
   - platform: template
-    name: "${name} discharging power"
+    name: "discharging power"
     id: smg0_discharging_power
     unit_of_measurement: "W"
     device_class: power
@@ -84,7 +84,7 @@ sensor:
       return (power < 0.0f) ? -power : 0.0f;
 
   - platform: template
-    name: "${name} charging power"
+    name: "charging power"
     id: smg0_charging_power
     unit_of_measurement: "W"
     device_class: power
@@ -102,7 +102,7 @@ sensor:
   # Fault code                                                    ULong 100 2 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} fault code"
+    name: "fault code"
     address: 100
     register_type: holding
     value_type: U_DWORD
@@ -112,7 +112,7 @@ sensor:
   # Warning code                                                  ULong 108 2 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} warning code"
+    name: "warning code"
     address: 108
     register_type: holding
     value_type: U_DWORD
@@ -128,7 +128,7 @@ sensor:
   #                                                                             6: Fault
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} operation mode id"
+    name: "operation mode id"
     address: 201
     register_type: holding
     value_type: U_WORD
@@ -138,7 +138,7 @@ sensor:
   # Effective mains voltage                              0.1V     Int   202 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} ac voltage"
+    name: "ac voltage"
     address: 202
     register_type: holding
     value_type: S_WORD
@@ -152,7 +152,7 @@ sensor:
   # Mains Frequency                                      0.01Hz   Int   203 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} ac frequency"
+    name: "ac frequency"
     address: 203
     register_type: holding
     value_type: S_WORD
@@ -166,7 +166,7 @@ sensor:
   # Average mains power                                  1W       Int   204 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} average mains power"
+    name: "average mains power"
     address: 204
     register_type: holding
     value_type: S_WORD
@@ -178,7 +178,7 @@ sensor:
   # Effective inverter voltage                           0.1V     Int   205 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} effective inverter voltage"
+    name: "effective inverter voltage"
     address: 205
     register_type: holding
     value_type: S_WORD
@@ -192,7 +192,7 @@ sensor:
   # Effective inverter current                           0.1A     Int   206 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} effective inverter current"
+    name: "effective inverter current"
     address: 206
     register_type: holding
     value_type: S_WORD
@@ -206,7 +206,7 @@ sensor:
   # Inverter frequency                                   0.01Hz   Int   207 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} inverter frequency"
+    name: "inverter frequency"
     address: 207
     register_type: holding
     value_type: S_WORD
@@ -220,7 +220,7 @@ sensor:
   # Average inverter power                               1W       Int   208 1 R Positive numbers indicate inverter output, negative numbers indicate inverter input
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} average inverter power"
+    name: "average inverter power"
     address: 208
     register_type: holding
     value_type: S_WORD
@@ -232,7 +232,7 @@ sensor:
   # Inverter charging power                              1W       Int   209 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} inverter charging power"
+    name: "inverter charging power"
     address: 209
     register_type: holding
     value_type: S_WORD
@@ -244,7 +244,7 @@ sensor:
   # Output effective voltage                             0.1V     Int   210 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output effective voltage"
+    name: "output effective voltage"
     address: 210
     register_type: holding
     value_type: S_WORD
@@ -258,7 +258,7 @@ sensor:
   # Output effective Current                             0.1A     Int   211 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output effective Current"
+    name: "output effective Current"
     address: 211
     register_type: holding
     value_type: S_WORD
@@ -272,7 +272,7 @@ sensor:
   # Output frequency                                     0.01Hz   Int   212 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output frequency"
+    name: "output frequency"
     address: 212
     register_type: holding
     value_type: S_WORD
@@ -286,7 +286,7 @@ sensor:
   # Output active power                                  1W       Int   213 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output active power"
+    name: "output active power"
     address: 213
     register_type: holding
     value_type: S_WORD
@@ -298,7 +298,7 @@ sensor:
   # Output apparent power                                1VA      Int   214 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output apparent power"
+    name: "output apparent power"
     address: 214
     register_type: holding
     value_type: S_WORD
@@ -310,7 +310,7 @@ sensor:
   # Battery average voltage                              0.1V     Int   215 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery average voltage"
+    name: "battery average voltage"
     address: 215
     register_type: holding
     value_type: S_WORD
@@ -324,7 +324,7 @@ sensor:
   # Battery average Current                              0.1A     Int   216 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery average current"
+    name: "battery average current"
     address: 216
     register_type: holding
     value_type: S_WORD
@@ -338,7 +338,7 @@ sensor:
   # Battery average power                                1W       Int   217 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery average power"
+    name: "battery average power"
     id: smg0_battery_average_power
     address: 217
     register_type: holding
@@ -354,7 +354,7 @@ sensor:
   # PV average voltage                                   0.1V     Int   219 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} pv average voltage"
+    name: "pv average voltage"
     address: 219
     register_type: holding
     value_type: S_WORD
@@ -368,7 +368,7 @@ sensor:
   # PV average current                                   0.1A     Int   220 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} pv average current"
+    name: "pv average current"
     address: 220
     register_type: holding
     value_type: S_WORD
@@ -383,7 +383,7 @@ sensor:
   - platform: modbus_controller
     modbus_controller_id: smg0
     id: smg0_pv_average_power
-    name: "${name} pv average power"
+    name: "pv average power"
     address: 223
     register_type: holding
     value_type: S_WORD
@@ -395,7 +395,7 @@ sensor:
   # PV charging average power                            1W       Int   224 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} pv charging average power"
+    name: "pv charging average power"
     address: 224
     register_type: holding
     value_type: S_WORD
@@ -407,7 +407,7 @@ sensor:
   # Load percentage                                      1%       Int   225 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} load percentage"
+    name: "load percentage"
     address: 225
     register_type: holding
     value_type: S_WORD
@@ -419,7 +419,7 @@ sensor:
   # DCDC Temperature                                     1°C      Int   226 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} dcdc temperature"
+    name: "dcdc temperature"
     address: 226
     register_type: holding
     value_type: S_WORD
@@ -431,7 +431,7 @@ sensor:
   # Inverter Temperature                                 1°C      Int   227 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} inverter temperature"
+    name: "inverter temperature"
     address: 227
     register_type: holding
     value_type: S_WORD
@@ -443,7 +443,7 @@ sensor:
   # Battery state of charge                              1%       UInt  229 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery state of charge"
+    name: "battery state of charge"
     address: 229
     register_type: holding
     value_type: U_WORD
@@ -455,7 +455,7 @@ sensor:
   # Battery average current                              0.1A     Int   232 1 R Positive number means charging, negative number means discharging
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery average current2"
+    name: "battery average current2"
     address: 232
     register_type: holding
     value_type: S_WORD
@@ -469,7 +469,7 @@ sensor:
   # Inverter charging average current                    0.1A     Int   233 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} inverter charging average current"
+    name: "inverter charging average current"
     address: 233
     register_type: holding
     value_type: S_WORD
@@ -483,7 +483,7 @@ sensor:
   # PV charging average current                          0.1A     Int   234 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} pv charging average current"
+    name: "pv charging average current"
     address: 234
     register_type: holding
     value_type: S_WORD
@@ -497,7 +497,7 @@ sensor:
   # # Output voltage                                        0.1V    Uint  320 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} output voltage"
+  #   name: "output voltage"
   #   address: 320
   #   register_type: holding
   #   value_type: U_WORD
@@ -511,7 +511,7 @@ sensor:
   # # Output frequency setting                              0.01Hz  Uint  321 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} output frequency setting"
+  #   name: "output frequency setting"
   #   address: 321
   #   register_type: holding
   #   value_type: U_WORD
@@ -525,7 +525,7 @@ sensor:
   # # Battery overvoltage protection point                  0.1V    Uint  323 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} battery overvoltage protection point"
+  #   name: "battery overvoltage protection point"
   #   address: 323
   #   register_type: holding
   #   value_type: U_WORD
@@ -539,7 +539,7 @@ sensor:
   # # Max charging voltage                                  0.1V    Uint  324 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} max charging voltage"
+  #   name: "max charging voltage"
   #   address: 324
   #   register_type: holding
   #   value_type: U_WORD
@@ -553,7 +553,7 @@ sensor:
   # # Floating charging voltage                             0.1V    Uint  325 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} floating charging voltage"
+  #   name: "floating charging voltage"
   #   address: 325
   #   register_type: holding
   #   value_type: U_WORD
@@ -567,7 +567,7 @@ sensor:
   # # Battery discharge recovery point in mains mode        0.1V    Uint  326 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} battery discharge recovery point in mains mode"
+  #   name: "battery discharge recovery point in mains mode"
   #   address: 326
   #   register_type: holding
   #   value_type: U_WORD
@@ -581,7 +581,7 @@ sensor:
   # # Battery low voltage protection point in mains mode    0.1V    Uint  327 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} battery low voltage protection point in mains mode"
+  #   name: "battery low voltage protection point in mains mode"
   #   address: 327
   #   register_type: holding
   #   value_type: U_WORD
@@ -595,7 +595,7 @@ sensor:
   # # Battery low voltage protection point in off-grid mode 0.1V    Uint  329 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} battery low voltage protection point in off-grid mode"
+  #   name: "battery low voltage protection point in off-grid mode"
   #   address: 329
   #   register_type: holding
   #   value_type: U_WORD
@@ -609,7 +609,7 @@ sensor:
   # # Maximum charging current                              0.1A    Uint  332 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} maximum charging current"
+  #   name: "maximum charging current"
   #   address: 332
   #   register_type: holding
   #   value_type: U_WORD
@@ -623,7 +623,7 @@ sensor:
   # # Maximum mains charging current                        0.1A    Uint  333 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} maximum mains charging current"
+  #   name: "maximum mains charging current"
   #   address: 333
   #   register_type: holding
   #   value_type: U_WORD
@@ -637,7 +637,7 @@ sensor:
   # # Eq Charging voltage                                   0.1V    Uint  334 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} Eq Charging voltage"
+  #   name: "Eq Charging voltage"
   #   address: 334
   #   register_type: holding
   #   value_type: U_WORD
@@ -651,7 +651,7 @@ sensor:
   # Rated power                                           W       Uint  643 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} rated power"
+    name: "rated power"
     address: 643
     register_type: holding
     value_type: U_WORD
@@ -664,7 +664,7 @@ select:
   # Output Mode                                                   Uint  300 1 R/W 0: Single, 1: Parallel, 2: 3 Phase-P1, 3: 3 Phase-P2, 4: 3 Phase-P3
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output mode"
+    name: "output mode"
     use_write_multiple: true
     address: 300
     value_type: U_WORD
@@ -680,7 +680,7 @@ select:
   # Output priority                                               Uint  301 1 R/W 0: Utility-PV-Battery, 1: PV-Utility-Battery, 2: PV-Battery-Utility
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output priority"
+    name: "output priority"
     use_write_multiple: true
     address: 301
     value_type: U_WORD
@@ -695,7 +695,7 @@ select:
   # Input voltage range                                           Uint  302 1 R/W 0: Wide range, 1: Narrow range
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} input voltage range"
+    name: "input voltage range"
     use_write_multiple: true
     address: 302
     value_type: U_WORD
@@ -708,7 +708,7 @@ select:
   # Buzzer mode                                                   Uint  303 1 R/W 0: Mute in all situations, 1: Sound when the input source is changed or there is a specific warning or fault, 2: Sound when there is aspecific warning or fault, 3: Sound when fault occurs
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} buzzer mode"
+    name: "buzzer mode"
     use_write_multiple: true
     address: 303
     value_type: U_WORD
@@ -723,7 +723,7 @@ select:
   # LCD backlight                                                 Uint  305 1 R/W 0: Timed off, 1: Always on
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} lcd backlight"
+    name: "lcd backlight"
     use_write_multiple: true
     address: 305
     value_type: U_WORD
@@ -736,7 +736,7 @@ select:
   # Battery charging priority                                     Uint  331 1 R/W 0: Utility priority, 1: PV priority, 2: PV is at the same level as the Utility, 3: Only PV charging is allowed
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery charging priority"
+    name: "battery charging priority"
     use_write_multiple: true
     address: 331
     value_type: U_WORD
@@ -751,7 +751,7 @@ select:
   # Turn on mode                                                  Uint  406 1 R/W 0: Can be turn-on locally or remotely, 1: Only local turn-on, 2: Only remote turn-on
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} turn on mode"
+    name: "turn on mode"
     use_write_multiple: true
     address: 406
     value_type: U_WORD
@@ -764,7 +764,7 @@ select:
 
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery type"
+    name: "battery type"
     use_write_multiple: true
     address: 322
     value_type: U_WORD
@@ -784,7 +784,7 @@ switch:
   # LCD automatically returns to the homepage                     Uint  306 1 R/W 0: Do not return automatically, 1: Automatically return after 1 minute
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} lcd automatically returns to the homepage"
+    name: "lcd automatically returns to the homepage"
     use_write_multiple: true
     address: 306
     register_type: holding
@@ -794,7 +794,7 @@ switch:
   # Energy-saving mode                                            Uint  307 1 R/W 0: Energy-saving mode is off, 1: Energy-saving mode is on
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} energy-saving mode"
+    name: "energy-saving mode"
     use_write_multiple: true
     address: 307
     register_type: holding
@@ -804,7 +804,7 @@ switch:
   # Overload automatic restart                                    Uint  308 1 R/W 0: Overload failure will not restart, 1: Automatic restart after overload failure
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} overload automatic restart"
+    name: "overload automatic restart"
     use_write_multiple: true
     address: 308
     register_type: holding
@@ -814,7 +814,7 @@ switch:
   # Over temperature automatic restart                            Uint  309 1 R/W 0: Over temperature failure will not restart, 1: Automatic restart after over-temperature fault
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} over temperature automatic restart"
+    name: "over temperature automatic restart"
     use_write_multiple: true
     address: 309
     register_type: holding
@@ -824,7 +824,7 @@ switch:
   # Overload transfer to bypass enabled                           Uint  310 1 R/W 0: Disable, 1: Enable
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} overload transfer to bypass enabled"
+    name: "overload transfer to bypass enabled"
     use_write_multiple: true
     address: 310
     register_type: holding
@@ -834,7 +834,7 @@ switch:
   # Battery Eq mode is enabled                                    Uint  313 1 R/W 0: Disable, 1: Enable
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery Eq mode is enabled"
+    name: "battery Eq mode is enabled"
     use_write_multiple: true
     address: 313
     register_type: holding
@@ -844,7 +844,7 @@ switch:
   # Remote switch                                                 Uint  420 1 R/W 0: Remote shutdown, 1: Remote turn-on
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} remote switch"
+    name: "remote switch"
     use_write_multiple: true
     address: 420
     register_type: holding
@@ -855,7 +855,7 @@ text_sensor:
   # Fault code                                                    ULong 100 2 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} fault"
+    name: "fault"
     address: 100
     register_type: holding
     register_count: 2
@@ -912,7 +912,7 @@ text_sensor:
   # Warning code                                                  ULong 108 2 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} warning"
+    name: "warning"
     address: 108
     register_type: holding
     register_count: 2
@@ -961,7 +961,7 @@ text_sensor:
   # Operation Mode                                                UInt  201 1 R 0: Power On, 1: Standby, 2: Mains, 3: Off-Grid, 4: Bypass, 5: Charging, 6: Fault
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} operation mode"
+    name: "operation mode"
     address: 201
     register_type: holding
     raw_encode: HEXBYTES
@@ -983,7 +983,7 @@ number:
   # Output voltage                                                0.1V    Uint  320 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output voltage"
+    name: "output voltage"
     use_write_multiple: true
     address: 320
     register_type: holding
@@ -1001,7 +1001,7 @@ number:
   # Output frequency setting                                      0.01Hz  Uint  321 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output frequency setting"
+    name: "output frequency setting"
     use_write_multiple: true
     address: 321
     register_type: holding
@@ -1019,7 +1019,7 @@ number:
   # Battery overvoltage protection point                          0.1V    Uint  323 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery overvoltage protection point"
+    name: "battery overvoltage protection point"
     use_write_multiple: true
     address: 323
     register_type: holding
@@ -1037,7 +1037,7 @@ number:
   # Max charging voltage                                          0.1V    Uint  324 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} max charging voltage"
+    name: "max charging voltage"
     use_write_multiple: true
     address: 324
     register_type: holding
@@ -1055,7 +1055,7 @@ number:
   # Floating charging voltage                                     0.1V    Uint  325 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} floating charging voltage"
+    name: "floating charging voltage"
     use_write_multiple: true
     address: 325
     register_type: holding
@@ -1073,7 +1073,7 @@ number:
   # Battery discharge recovery point in mains mode                0.1V    Uint  326 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery discharge recovery point in mains mode"
+    name: "battery discharge recovery point in mains mode"
     use_write_multiple: true
     address: 326
     register_type: holding
@@ -1091,7 +1091,7 @@ number:
   # Battery low voltage protection point in mains mode            0.1V    Uint  327 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery low voltage protection point in mains mode"
+    name: "battery low voltage protection point in mains mode"
     use_write_multiple: true
     address: 327
     register_type: holding
@@ -1109,7 +1109,7 @@ number:
   # Battery low voltage protection point in off-grid mode          0.1V           Uint  329 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery low voltage protection point in off-grid mode"
+    name: "battery low voltage protection point in off-grid mode"
     use_write_multiple: true
     address: 329
     register_type: holding
@@ -1127,7 +1127,7 @@ number:
   # Maximum charging current                                      0.1A    Uint  332 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} maximum charging current"
+    name: "maximum charging current"
     use_write_multiple: true
     address: 332
     register_type: holding
@@ -1145,7 +1145,7 @@ number:
   # Maximum mains charging current                                0.1A    Uint  333 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} maximum mains charging current"
+    name: "maximum mains charging current"
     use_write_multiple: true
     address: 333
     register_type: holding
@@ -1163,7 +1163,7 @@ number:
   # Eq Charging voltage                                           0.1V    Uint  334 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} Eq Charging voltage"
+    name: "Eq Charging voltage"
     use_write_multiple: true
     address: 334
     register_type: holding
@@ -1181,7 +1181,7 @@ number:
   # Battery equalization time                                     min     Uint  335 1 R/W Range: 0~900
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery equalization time"
+    name: "battery equalization time"
     use_write_multiple: true
     address: 335
     register_type: holding
@@ -1196,7 +1196,7 @@ number:
   # Equalization Timeout exit                                     min     Uint  336 1 R/W Range: 0~900
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} equalization Timeout exit"
+    name: "equalization Timeout exit"
     use_write_multiple: true
     address: 336
     register_type: holding
@@ -1211,7 +1211,7 @@ number:
   # Two equalization charging intervals                           day     Uint  337 1 R/W Range: 1~90
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} two equalization charging intervals"
+    name: "two equalization charging intervals"
     use_write_multiple: true
     address: 337
     register_type: holding
@@ -1226,7 +1226,7 @@ number:
 button:
   # Exit the fault mode                                           Uint  426   W   1: Exit the fault state
   - platform: template
-    name: "${name} exit fault state"
+    name: "exit fault state"
     icon: mdi:restore
     on_press:
       then:

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   min_version: 2024.6.0
   project:

--- a/tests/esp32-uart-trx1.yaml
+++ b/tests/esp32-uart-trx1.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.6.0
 
 esp32:

--- a/tests/esp32-uart-trx2.yaml
+++ b/tests/esp32-uart-trx2.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.6.0
 
 esp32:

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -49,7 +49,7 @@ time:
 
 sensor:
   - platform: total_daily_energy
-    name: "${name} PV energy today"
+    name: "PV energy today"
     restore: true
     icon: mdi:counter
     power_id: smg0_pv_average_power
@@ -61,7 +61,7 @@ sensor:
   # Fault code                                                    ULong 100 2 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} fault code"
+    name: "fault code"
     address: 100
     register_type: holding
     value_type: U_DWORD
@@ -70,7 +70,7 @@ sensor:
   # Warning code                                                  ULong 108 2 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} warning code"
+    name: "warning code"
     address: 108
     register_type: holding
     value_type: U_DWORD
@@ -85,7 +85,7 @@ sensor:
   #                                                                             6: Fault
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} operation mode id"
+    name: "operation mode id"
     address: 201
     register_type: holding
     value_type: U_WORD
@@ -94,7 +94,7 @@ sensor:
   # Effective mains voltage                              0.1V     Int   202 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} ac voltage"
+    name: "ac voltage"
     address: 202
     register_type: holding
     value_type: S_WORD
@@ -108,7 +108,7 @@ sensor:
   # Mains Frequency                                      0.01Hz   Int   203 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} ac frequency"
+    name: "ac frequency"
     address: 203
     register_type: holding
     value_type: S_WORD
@@ -122,7 +122,7 @@ sensor:
   # Average mains power                                  1W       Int   204 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} average mains power"
+    name: "average mains power"
     address: 204
     register_type: holding
     value_type: S_WORD
@@ -134,7 +134,7 @@ sensor:
   # Effective inverter voltage                           0.1V     Int   205 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} effective inverter voltage"
+    name: "effective inverter voltage"
     address: 205
     register_type: holding
     value_type: S_WORD
@@ -148,7 +148,7 @@ sensor:
   # Effective inverter current                           0.1A     Int   206 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} effective inverter current"
+    name: "effective inverter current"
     address: 206
     register_type: holding
     value_type: S_WORD
@@ -162,7 +162,7 @@ sensor:
   # Inverter frequency                                   0.01Hz   Int   207 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} inverter frequency"
+    name: "inverter frequency"
     address: 207
     register_type: holding
     value_type: S_WORD
@@ -176,7 +176,7 @@ sensor:
   # Average inverter power                               1W       Int   208 1 R Positive numbers indicate inverter output, negative numbers indicate inverter input
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} average inverter power"
+    name: "average inverter power"
     address: 208
     register_type: holding
     value_type: S_WORD
@@ -188,7 +188,7 @@ sensor:
   # Inverter charging power                              1W       Int   209 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} inverter charging power"
+    name: "inverter charging power"
     address: 209
     register_type: holding
     value_type: S_WORD
@@ -200,7 +200,7 @@ sensor:
   # Output effective voltage                             0.1V     Int   210 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output effective voltage"
+    name: "output effective voltage"
     address: 210
     register_type: holding
     value_type: S_WORD
@@ -214,7 +214,7 @@ sensor:
   # Output effective Current                             0.1A     Int   211 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output effective Current"
+    name: "output effective Current"
     address: 211
     register_type: holding
     value_type: S_WORD
@@ -228,7 +228,7 @@ sensor:
   # Output frequency                                     0.01Hz   Int   212 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output frequency"
+    name: "output frequency"
     address: 212
     register_type: holding
     value_type: S_WORD
@@ -242,7 +242,7 @@ sensor:
   # Output active power                                  1W       Int   213 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output active power"
+    name: "output active power"
     address: 213
     register_type: holding
     value_type: S_WORD
@@ -254,7 +254,7 @@ sensor:
   # Output apparent power                                1VA      Int   214 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output apparent power"
+    name: "output apparent power"
     address: 214
     register_type: holding
     value_type: S_WORD
@@ -266,7 +266,7 @@ sensor:
   # Battery average voltage                              0.1V     Int   215 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery average voltage"
+    name: "battery average voltage"
     address: 215
     register_type: holding
     value_type: S_WORD
@@ -280,7 +280,7 @@ sensor:
   # Battery average Current                              0.1A     Int   216 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery average current"
+    name: "battery average current"
     address: 216
     register_type: holding
     value_type: S_WORD
@@ -294,7 +294,7 @@ sensor:
   # Battery average power                                1W       Int   217 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery average power"
+    name: "battery average power"
     address: 217
     register_type: holding
     value_type: S_WORD
@@ -306,7 +306,7 @@ sensor:
   # PV average voltage                                   0.1V     Int   219 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} pv average voltage"
+    name: "pv average voltage"
     address: 219
     register_type: holding
     value_type: S_WORD
@@ -320,7 +320,7 @@ sensor:
   # PV average current                                   0.1A     Int   220 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} pv average current"
+    name: "pv average current"
     address: 220
     register_type: holding
     value_type: S_WORD
@@ -335,7 +335,7 @@ sensor:
   - platform: modbus_controller
     modbus_controller_id: smg0
     id: smg0_pv_average_power
-    name: "${name} pv average power"
+    name: "pv average power"
     address: 223
     register_type: holding
     value_type: S_WORD
@@ -347,7 +347,7 @@ sensor:
   # PV charging average power                            1W       Int   224 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} pv charging average power"
+    name: "pv charging average power"
     address: 224
     register_type: holding
     value_type: S_WORD
@@ -359,7 +359,7 @@ sensor:
   # Load percentage                                      1%       Int   225 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} load percentage"
+    name: "load percentage"
     address: 225
     register_type: holding
     value_type: S_WORD
@@ -371,7 +371,7 @@ sensor:
   # DCDC Temperature                                     1°C      Int   226 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} dcdc temperature"
+    name: "dcdc temperature"
     address: 226
     register_type: holding
     value_type: S_WORD
@@ -383,7 +383,7 @@ sensor:
   # Inverter Temperature                                 1°C      Int   227 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} inverter temperature"
+    name: "inverter temperature"
     address: 227
     register_type: holding
     value_type: S_WORD
@@ -395,7 +395,7 @@ sensor:
   # Battery state of charge                              1%       UInt  229 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery state of charge"
+    name: "battery state of charge"
     address: 229
     register_type: holding
     value_type: U_WORD
@@ -407,7 +407,7 @@ sensor:
   # Battery average current                              0.1A     Int   232 1 R Positive number means charging, negative number means discharging
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery average current2"
+    name: "battery average current2"
     address: 232
     register_type: holding
     value_type: S_WORD
@@ -421,7 +421,7 @@ sensor:
   # Inverter charging average current                    0.1A     Int   233 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} inverter charging average current"
+    name: "inverter charging average current"
     address: 233
     register_type: holding
     value_type: S_WORD
@@ -435,7 +435,7 @@ sensor:
   # PV charging average current                          0.1A     Int   234 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} pv charging average current"
+    name: "pv charging average current"
     address: 234
     register_type: holding
     value_type: S_WORD
@@ -449,7 +449,7 @@ sensor:
   # # Output voltage                                        0.1V    Uint  320 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} output voltage"
+  #   name: "output voltage"
   #   address: 320
   #   register_type: holding
   #   value_type: U_WORD
@@ -463,7 +463,7 @@ sensor:
   # # Output frequency setting                              0.01Hz  Uint  321 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} output frequency setting"
+  #   name: "output frequency setting"
   #   address: 321
   #   register_type: holding
   #   value_type: U_WORD
@@ -477,7 +477,7 @@ sensor:
   # # Battery overvoltage protection point                  0.1V    Uint  323 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} battery overvoltage protection point"
+  #   name: "battery overvoltage protection point"
   #   address: 323
   #   register_type: holding
   #   value_type: U_WORD
@@ -491,7 +491,7 @@ sensor:
   # # Max charging voltage                                  0.1V    Uint  324 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} max charging voltage"
+  #   name: "max charging voltage"
   #   address: 324
   #   register_type: holding
   #   value_type: U_WORD
@@ -505,7 +505,7 @@ sensor:
   # # Floating charging voltage                             0.1V    Uint  325 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} floating charging voltage"
+  #   name: "floating charging voltage"
   #   address: 325
   #   register_type: holding
   #   value_type: U_WORD
@@ -519,7 +519,7 @@ sensor:
   # # Battery discharge recovery point in mains mode        0.1V    Uint  326 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} battery discharge recovery point in mains mode"
+  #   name: "battery discharge recovery point in mains mode"
   #   address: 326
   #   register_type: holding
   #   value_type: U_WORD
@@ -533,7 +533,7 @@ sensor:
   # # Battery low voltage protection point in mains mode    0.1V    Uint  327 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} battery low voltage protection point in mains mode"
+  #   name: "battery low voltage protection point in mains mode"
   #   address: 327
   #   register_type: holding
   #   value_type: U_WORD
@@ -547,7 +547,7 @@ sensor:
   # # Battery low voltage protection point in off-grid mode 0.1V    Uint  329 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} battery low voltage protection point in off-grid mode"
+  #   name: "battery low voltage protection point in off-grid mode"
   #   address: 329
   #   register_type: holding
   #   value_type: U_WORD
@@ -561,7 +561,7 @@ sensor:
   # # Maximum charging current                              0.1A    Uint  332 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} maximum charging current"
+  #   name: "maximum charging current"
   #   address: 332
   #   register_type: holding
   #   value_type: U_WORD
@@ -575,7 +575,7 @@ sensor:
   # # Maximum mains charging current                        0.1A    Uint  333 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} maximum mains charging current"
+  #   name: "maximum mains charging current"
   #   address: 333
   #   register_type: holding
   #   value_type: U_WORD
@@ -589,7 +589,7 @@ sensor:
   # # Eq Charging voltage                                   0.1V    Uint  334 1 R/W
   # - platform: modbus_controller
   #   modbus_controller_id: smg0
-  #   name: "${name} Eq Charging voltage"
+  #   name: "Eq Charging voltage"
   #   address: 334
   #   register_type: holding
   #   value_type: U_WORD
@@ -603,7 +603,7 @@ sensor:
   # Rated power                                           W       Uint  643 1 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} rated power"
+    name: "rated power"
     address: 643
     register_type: holding
     value_type: U_WORD
@@ -616,7 +616,7 @@ select:
   # Output Mode                                                   Uint  300 1 R/W 0: Single, 1: Parallel, 2: 3 Phase-P1, 3: 3 Phase-P2, 4: 3 Phase-P3
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output mode"
+    name: "output mode"
     use_write_multiple: true
     address: 300
     value_type: U_WORD
@@ -630,7 +630,7 @@ select:
   # Output priority                                               Uint  301 1 R/W 0: Utility-PV-Battery, 1: PV-Utility-Battery, 2: PV-Battery-Utility
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output priority"
+    name: "output priority"
     use_write_multiple: true
     address: 301
     value_type: U_WORD
@@ -643,7 +643,7 @@ select:
   # Input voltage range                                           Uint  302 1 R/W 0: Wide range, 1: Narrow range
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} input voltage range"
+    name: "input voltage range"
     use_write_multiple: true
     address: 302
     value_type: U_WORD
@@ -654,7 +654,7 @@ select:
   # Buzzer mode                                                   Uint  303 1 R/W 0: Mute in all situations, 1: Sound when the input source is changed or there is a specific warning or fault, 2: Sound when there is aspecific warning or fault, 3: Sound when fault occurs
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} buzzer mode"
+    name: "buzzer mode"
     use_write_multiple: true
     address: 303
     value_type: U_WORD
@@ -667,7 +667,7 @@ select:
   # LCD backlight                                                 Uint  305 1 R/W 0: Timed off, 1: Always on
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} lcd backlight"
+    name: "lcd backlight"
     use_write_multiple: true
     address: 305
     value_type: U_WORD
@@ -678,7 +678,7 @@ select:
   # Battery charging priority                                     Uint  331 1 R/W 0: Utility priority, 1: PV priority, 2: PV is at the same level as the Utility, 3: Only PV charging is allowed
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery charging priority"
+    name: "battery charging priority"
     use_write_multiple: true
     address: 331
     value_type: U_WORD
@@ -691,7 +691,7 @@ select:
   # Turn on mode                                                  Uint  406 1 R/W 0: Can be turn-on locally or remotely, 1: Only local turn-on, 2: Only remote turn-on
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} turn on mode"
+    name: "turn on mode"
     use_write_multiple: true
     address: 406
     value_type: U_WORD
@@ -704,7 +704,7 @@ switch:
   # LCD automatically returns to the homepage                     Uint  306 1 R/W 0: Do not return automatically, 1: Automatically return after 1 minute
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} lcd automatically returns to the homepage"
+    name: "lcd automatically returns to the homepage"
     use_write_multiple: true
     address: 306
     register_type: holding
@@ -713,7 +713,7 @@ switch:
   # Energy-saving mode                                            Uint  307 1 R/W 0: Energy-saving mode is off, 1: Energy-saving mode is on
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} energy-saving mode"
+    name: "energy-saving mode"
     use_write_multiple: true
     address: 307
     register_type: holding
@@ -722,7 +722,7 @@ switch:
   # Overload automatic restart                                    Uint  308 1 R/W 0: Overload failure will not restart, 1: Automatic restart after overload failure
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} overload automatic restart"
+    name: "overload automatic restart"
     use_write_multiple: true
     address: 308
     register_type: holding
@@ -731,7 +731,7 @@ switch:
   # Over temperature automatic restart                            Uint  309 1 R/W 0: Over temperature failure will not restart, 1: Automatic restart after over-temperature fault
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} over temperature automatic restart"
+    name: "over temperature automatic restart"
     use_write_multiple: true
     address: 309
     register_type: holding
@@ -740,7 +740,7 @@ switch:
   # Overload transfer to bypass enabled                           Uint  310 1 R/W 0: Disable, 1: Enable
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} overload transfer to bypass enabled"
+    name: "overload transfer to bypass enabled"
     use_write_multiple: true
     address: 310
     register_type: holding
@@ -749,7 +749,7 @@ switch:
   # Battery Eq mode is enabled                                    Uint  313 1 R/W 0: Disable, 1: Enable
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery Eq mode is enabled"
+    name: "battery Eq mode is enabled"
     use_write_multiple: true
     address: 313
     register_type: holding
@@ -758,7 +758,7 @@ switch:
   # Remote switch                                                 Uint  420 1 R/W 0: Remote shutdown, 1: Remote turn-on
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} remote switch"
+    name: "remote switch"
     use_write_multiple: true
     address: 420
     register_type: holding
@@ -768,7 +768,7 @@ text_sensor:
   # Fault code                                                    ULong 100 2 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} fault"
+    name: "fault"
     address: 100
     register_type: holding
     register_count: 2
@@ -824,7 +824,7 @@ text_sensor:
   # Warning code                                                  ULong 108 2 R
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} warning"
+    name: "warning"
     address: 108
     register_type: holding
     register_count: 2
@@ -872,7 +872,7 @@ text_sensor:
   # Operation Mode                                                UInt  201 1 R 0: Power On, 1: Standby, 2: Mains, 3: Off-Grid, 4: Bypass, 5: Charging, 6: Fault
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} operation mode"
+    name: "operation mode"
     address: 201
     register_type: holding
     raw_encode: HEXBYTES
@@ -893,7 +893,7 @@ number:
   # Output voltage                                                0.1V    Uint  320 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output voltage"
+    name: "output voltage"
     use_write_multiple: true
     address: 320
     register_type: holding
@@ -909,7 +909,7 @@ number:
   # Output frequency setting                                      0.01Hz  Uint  321 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} output frequency setting"
+    name: "output frequency setting"
     use_write_multiple: true
     address: 321
     register_type: holding
@@ -925,7 +925,7 @@ number:
   # Battery overvoltage protection point                          0.1V    Uint  323 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery overvoltage protection point"
+    name: "battery overvoltage protection point"
     use_write_multiple: true
     address: 323
     register_type: holding
@@ -941,7 +941,7 @@ number:
   # Max charging voltage                                          0.1V    Uint  324 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} max charging voltage"
+    name: "max charging voltage"
     use_write_multiple: true
     address: 324
     register_type: holding
@@ -957,7 +957,7 @@ number:
   # Floating charging voltage                                     0.1V    Uint  325 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} floating charging voltage"
+    name: "floating charging voltage"
     use_write_multiple: true
     address: 325
     register_type: holding
@@ -973,7 +973,7 @@ number:
   # Battery discharge recovery point in mains mode                0.1V    Uint  326 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery discharge recovery point in mains mode"
+    name: "battery discharge recovery point in mains mode"
     use_write_multiple: true
     address: 326
     register_type: holding
@@ -989,7 +989,7 @@ number:
   # Battery low voltage protection point in mains mode            0.1V    Uint  327 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery low voltage protection point in mains mode"
+    name: "battery low voltage protection point in mains mode"
     use_write_multiple: true
     address: 327
     register_type: holding
@@ -1005,7 +1005,7 @@ number:
   # Battery low voltage protection point in off-grid mode          0.1V           Uint  329 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery low voltage protection point in off-grid mode"
+    name: "battery low voltage protection point in off-grid mode"
     use_write_multiple: true
     address: 329
     register_type: holding
@@ -1021,7 +1021,7 @@ number:
   # Maximum charging current                                      0.1A    Uint  332 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} maximum charging current"
+    name: "maximum charging current"
     use_write_multiple: true
     address: 332
     register_type: holding
@@ -1037,7 +1037,7 @@ number:
   # Maximum mains charging current                                0.1A    Uint  333 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} maximum mains charging current"
+    name: "maximum mains charging current"
     use_write_multiple: true
     address: 333
     register_type: holding
@@ -1053,7 +1053,7 @@ number:
   # Eq Charging voltage                                           0.1V    Uint  334 1 R/W
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} Eq Charging voltage"
+    name: "Eq Charging voltage"
     use_write_multiple: true
     address: 334
     register_type: holding
@@ -1069,7 +1069,7 @@ number:
   # Battery equalization time                                     min     Uint  335 1 R/W Range: 0~900
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} battery equalization time"
+    name: "battery equalization time"
     use_write_multiple: true
     address: 335
     register_type: holding
@@ -1082,7 +1082,7 @@ number:
   # Equalization Timeout exit                                     min     Uint  336 1 R/W Range: 0~900
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} equalization Timeout exit"
+    name: "equalization Timeout exit"
     use_write_multiple: true
     address: 336
     register_type: holding
@@ -1095,7 +1095,7 @@ number:
   # Two equalization charging intervals                           day     Uint  337 1 R/W Range: 1~90
   - platform: modbus_controller
     modbus_controller_id: smg0
-    name: "${name} two equalization charging intervals"
+    name: "two equalization charging intervals"
     use_write_multiple: true
     address: 337
     register_type: holding

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -4,6 +4,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   min_version: 2025.6.0
 

--- a/yaml-snippets/esp32-emulate-li4-battery-bank.yaml
+++ b/yaml-snippets/esp32-emulate-li4-battery-bank.yaml
@@ -12,6 +12,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   min_version: 2024.6.0
   project:


### PR DESCRIPTION
ESPHome's `friendly_name` automatically prefixes all entity names, making the `${name}` substitution in entity name strings redundant.