### PR TITLE
Update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/actions/restore-python/action.yml
+++ b/.github/actions/restore-python/action.yml
@@ -17,12 +17,12 @@ runs:
   steps:
     - name: Set up Python ${{ inputs.python-version }}
       id: python
-      uses: actions/setup-python@v5.6.0
+      uses: actions/setup-python@v6.2.0
       with:
         python-version: ${{ inputs.python-version }}
     - name: Restore Python virtual environment
       id: cache-venv
-      uses: actions/cache/restore@v4.2.3
+      uses: actions/cache/restore@v5.0.4
       with:
         path: venv
         # yamllint disable-line rule:line-length

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,9 @@ jobs:
   yamllint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.3.1
       - name: Run yamllint
-        uses: frenck/action-yamllint@v1
+        uses: frenck/action-yamllint@v1.5.0
         with:
           config: .yamllint
 
@@ -39,10 +39,10 @@ jobs:
       repo-hash: ${{ github.sha }}
     steps:
       - name: Check out this project
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.3.1
 
       - name: Check out code from ESPHome project
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.3.1
         with:
           repository: esphome/esphome
           ref: dev
@@ -54,7 +54,7 @@ jobs:
           ln -sf ../venv venv
 
       - name: Archive prepared repository
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v7
         with:
           name: bundle
           path: .
@@ -69,7 +69,7 @@ jobs:
       cache-key: ${{ steps.cache-key.outputs.key }}
     steps:
       - name: Download prepared repository
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v8
         with:
           name: bundle
           path: .
@@ -81,12 +81,12 @@ jobs:
         run: echo key="${{ hashFiles('esphome/requirements.txt', 'esphome/requirements_test.txt') }}" >> $GITHUB_OUTPUT
       - name: Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
-        uses: actions/setup-python@v5.6.0
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Restore Python virtual environment
         id: cache-venv
-        uses: actions/cache@v4.2.3
+        uses: actions/cache@v5.0.4
         with:
           path: venv
           # yamllint disable-line rule:line-length
@@ -110,7 +110,7 @@ jobs:
       - common
     steps:
       - name: Download prepared repository
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v8
         with:
           name: bundle
           path: .
@@ -153,7 +153,7 @@ jobs:
       - common
     steps:
       - name: Download prepared repository
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v8
         with:
           name: bundle
           path: .


### PR DESCRIPTION
## Summary

- `actions/checkout`: v4.1.7 → v4.3.1 (Node.js 24 compatible)
- `actions/setup-python`: v5.6.0 → v6.2.0 (Node.js 24 compatible)
- `actions/cache`: v4.2.3 → v5.0.4 (Node.js 24 compatible)
- `actions/cache/restore`: v4.2.3 → v5.0.4 (Node.js 24 compatible)
- `pyTooling/upload-artifact`: v4 → v7 (wraps upload-artifact@v7, Node.js 24)
- `pyTooling/download-artifact`: v4 → v8 (wraps download-artifact@v8, Node.js 24)

GitHub is deprecating all actions running on Node.js 20. Forced migration deadline is June 2, 2026; Node.js 20 will be removed September 16, 2026.