### PR TITLE
Fix deprecated modbus_controller:: helper functions in lambdas

### DIFF
--- a/esp32-example-advanced-multiple-uarts.yaml
+++ b/esp32-example-advanced-multiple-uarts.yaml
@@ -166,7 +166,7 @@ text_sensor:
     raw_encode: HEXBYTES
     icon: mdi:information
     lambda: |-
-      uint16_t value = modbus_controller::word_from_hex_str(x, 0);
+      uint16_t value = modbus::helpers::word_from_hex_str(x, 0);
       switch (value) {
         case 0: return std::string("Power On");
         case 1: return std::string("Standby");
@@ -186,7 +186,7 @@ text_sensor:
     raw_encode: HEXBYTES
     icon: mdi:information
     lambda: |-
-      uint16_t value = modbus_controller::word_from_hex_str(x, 0);
+      uint16_t value = modbus::helpers::word_from_hex_str(x, 0);
       switch (value) {
         case 0: return std::string("Power On");
         case 1: return std::string("Standby");

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -898,7 +898,7 @@ text_sensor:
       };
       std::string values = "";
 
-      uint32_t mask = modbus_controller::dword_from_hex_str(x, 0);
+      uint32_t mask = modbus::helpers::dword_from_hex_str(x, 0);
       if (mask) {
         for (int i = 0; i < FAULTS_SIZE; i++) {
           if (mask & (1 << i)) {
@@ -947,7 +947,7 @@ text_sensor:
       };
       std::string values = "";
 
-      uint32_t mask = modbus_controller::dword_from_hex_str(x, 0);
+      uint32_t mask = modbus::helpers::dword_from_hex_str(x, 0);
       if (mask) {
         for (int i = 0; i < WARNINGS_SIZE; i++) {
           if (mask & (1 << i)) {
@@ -970,7 +970,7 @@ text_sensor:
     raw_encode: HEXBYTES
     icon: mdi:information
     lambda: |-
-      uint16_t value = modbus_controller::word_from_hex_str(x, 0);
+      uint16_t value = modbus::helpers::word_from_hex_str(x, 0);
       switch (value) {
         case 0: return std::string("Power On");
         case 1: return std::string("Standby");

--- a/esp32-gm6200-example.yaml
+++ b/esp32-gm6200-example.yaml
@@ -922,7 +922,7 @@ text_sensor:
       };
       std::string values = "";
 
-      uint32_t mask = modbus_controller::dword_from_hex_str(x, 0);
+      uint32_t mask = modbus::helpers::dword_from_hex_str(x, 0);
       if (mask) {
         for (int i = 0; i < FAULTS_SIZE; i++) {
           if (mask & (1 << i)) {
@@ -974,7 +974,7 @@ text_sensor:
       };
       std::string values = "";
 
-      uint32_t mask = modbus_controller::dword_from_hex_str(x, 0);
+      uint32_t mask = modbus::helpers::dword_from_hex_str(x, 0);
       if (mask) {
         for (int i = 0; i < WARNINGS_SIZE; i++) {
           if (mask & (1 << i)) {
@@ -1017,7 +1017,7 @@ text_sensor:
     raw_encode: HEXBYTES
     icon: mdi:information
     lambda: |-
-      uint16_t value = modbus_controller::word_from_hex_str(x, 0);
+      uint16_t value = modbus::helpers::word_from_hex_str(x, 0);
       switch (value) {
         case 0: return std::string("Power On");
         case 1: return std::string("Standby");

--- a/esp32-srne-asf-example.yaml
+++ b/esp32-srne-asf-example.yaml
@@ -862,7 +862,7 @@ text_sensor:
     register_type: holding
     raw_encode: HEXBYTES
     lambda: |-
-      uint16_t value = modbus_controller::word_from_hex_str(x, 0);
+      uint16_t value = modbus::helpers::word_from_hex_str(x, 0);
       switch (value) {
         case 0: return std::string("Power On");
         case 1: return std::string("Standby");
@@ -883,7 +883,7 @@ text_sensor:
     register_type: holding
     raw_encode: HEXBYTES
     lambda: |-
-      uint16_t value = modbus_controller::word_from_hex_str(x, 0);
+      uint16_t value = modbus::helpers::word_from_hex_str(x, 0);
       switch (value) {
         case 0: return std::string("Charge Off");
         case 1: return std::string("Quick Charge");

--- a/esp32-usb-example.yaml
+++ b/esp32-usb-example.yaml
@@ -913,7 +913,7 @@ text_sensor:
       };
       std::string values = "";
 
-      uint32_t mask = modbus_controller::dword_from_hex_str(x, 0);
+      uint32_t mask = modbus::helpers::dword_from_hex_str(x, 0);
       if (mask) {
         for (int i = 0; i < FAULTS_SIZE; i++) {
           if (mask & (1 << i)) {
@@ -962,7 +962,7 @@ text_sensor:
       };
       std::string values = "";
 
-      uint32_t mask = modbus_controller::dword_from_hex_str(x, 0);
+      uint32_t mask = modbus::helpers::dword_from_hex_str(x, 0);
       if (mask) {
         for (int i = 0; i < WARNINGS_SIZE; i++) {
           if (mask & (1 << i)) {
@@ -985,7 +985,7 @@ text_sensor:
     raw_encode: HEXBYTES
     icon: mdi:information
     lambda: |-
-      uint16_t value = modbus_controller::word_from_hex_str(x, 0);
+      uint16_t value = modbus::helpers::word_from_hex_str(x, 0);
       switch (value) {
         case 0: return std::string("Power On");
         case 1: return std::string("Standby");

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -896,7 +896,7 @@ text_sensor:
       };
       std::string values = "";
 
-      uint32_t mask = modbus_controller::dword_from_hex_str(x, 0);
+      uint32_t mask = modbus::helpers::dword_from_hex_str(x, 0);
       if (mask) {
         for (int i = 0; i < FAULTS_SIZE; i++) {
           if (mask & (1 << i)) {
@@ -945,7 +945,7 @@ text_sensor:
       };
       std::string values = "";
 
-      uint32_t mask = modbus_controller::dword_from_hex_str(x, 0);
+      uint32_t mask = modbus::helpers::dword_from_hex_str(x, 0);
       if (mask) {
         for (int i = 0; i < WARNINGS_SIZE; i++) {
           if (mask & (1 << i)) {
@@ -968,7 +968,7 @@ text_sensor:
     raw_encode: HEXBYTES
     icon: mdi:information
     lambda: |-
-      uint16_t value = modbus_controller::word_from_hex_str(x, 0);
+      uint16_t value = modbus::helpers::word_from_hex_str(x, 0);
       switch (value) {
         case 0: return std::string("Power On");
         case 1: return std::string("Standby");

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -808,7 +808,7 @@ text_sensor:
       };
       std::string values = "";
 
-      uint32_t mask = modbus_controller::dword_from_hex_str(x, 0);
+      uint32_t mask = modbus::helpers::dword_from_hex_str(x, 0);
       if (mask) {
         for (int i = 0; i < FAULTS_SIZE; i++) {
           if (mask & (1 << i)) {
@@ -856,7 +856,7 @@ text_sensor:
       };
       std::string values = "";
 
-      uint32_t mask = modbus_controller::dword_from_hex_str(x, 0);
+      uint32_t mask = modbus::helpers::dword_from_hex_str(x, 0);
       if (mask) {
         for (int i = 0; i < WARNINGS_SIZE; i++) {
           if (mask & (1 << i)) {
@@ -878,7 +878,7 @@ text_sensor:
     register_type: holding
     raw_encode: HEXBYTES
     lambda: |-
-      uint16_t value = modbus_controller::word_from_hex_str(x, 0);
+      uint16_t value = modbus::helpers::word_from_hex_str(x, 0);
       switch (value) {
         case 0: return std::string("Power On");
         case 1: return std::string("Standby");


### PR DESCRIPTION
## Summary

- Replace `modbus_controller::dword_from_hex_str()` and `modbus_controller::word_from_hex_str()` with `modbus::helpers::dword_from_hex_str()` and `modbus::helpers::word_from_hex_str()` across all YAML example files
- Affects 7 files (19 occurrences): `esp8266-example.yaml`, `esp32-example.yaml`, `esp32-gm6200-example.yaml`, `esp32-usb-example.yaml`, `esp32-srne-asf-example.yaml`, `esp32-example-advanced-multiple-uarts.yaml`, `tests/esp32c6-compatibility-test.yaml`

## Background

ESPHome 2026.4.0 deprecated the helper functions in the `modbus_controller::` namespace and moved them to `modbus::helpers::`. The old names still work as wrappers but generate compiler warnings. They will be removed entirely in ESPHome 2026.10.0 at which point the current lambdas would cause a compilation error.

Closes #147 (partial - addresses the deprecation warnings; the "no data" issue reported there is an upstream ESPHome regression unrelated to these helpers)