### PR TITLE
Add Anenji 6200W-WiFi as supported device

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ESPHome configuration to monitor and control a ISolar/EASUN SMG II inverter via 
 * PowMr POW-HVM5.5K-48V / POW-HVM5.5K-48V-P
 * Qoltec 53963 (supports SUF output priority)
 * Anenji 3kW-24Vdc-120Vac (supports SUF output priority)
-* Anenji 6200W-WiFi (charging priority "Utility first" not supported)
+* Anenji 6200W-WiFi (charging priority "Utility first" probably not supported)
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ ESPHome configuration to monitor and control a ISolar/EASUN SMG II inverter via 
 * PowMr POW-HVM5.5K-48V / POW-HVM5.5K-48V-P
 * Qoltec 53963 (supports SUF output priority)
 * Anenji 3kW-24Vdc-120Vac (supports SUF output priority)
+* Anenji 6200W-WiFi (charging priority "Utility first" not supported)
 
 ## Requirements
 


### PR DESCRIPTION
Closes #134

Adds the Anenji 6200W-WiFi to the list of supported devices. The charging priority "Utility first" is not supported by this model - the hardware uses the main inverter in reverse for grid charging, which prevents simultaneous bidirectional operation.